### PR TITLE
#758 Remember tree selected item on update

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/base/TreeView.java
@@ -116,9 +116,11 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
     synchronized (viewModelLock) {
       localViewModel = this.viewModel;
     }
-    Set<String> expandedState = getExpandedState();
+    var expandedState = getExpandedState();
+    var selection = getSelectionRows();
     setModel(TREE_MODEL_BUILDER.build(localViewModel));
     restoreExpandedState(expandedState);
+    setSelectionRows(selection);
   }
 
   public void addNodeAppliedListener(ActionListener listener) {
@@ -142,9 +144,9 @@ public class TreeView extends com.intellij.ui.treeStructure.Tree {
     TreeModel treeModel = getModel();
     return treeModel == null ? Collections.emptySet()
         : new TreeModelTraverser(treeModel).traverse()
-            .filter(this::isExpanded)
-            .map(new TreePathStringEncoder()::encode)
-            .collect(Collectors.toSet());
+        .filter(this::isExpanded)
+        .map(new TreePathStringEncoder()::encode)
+        .collect(Collectors.toSet());
   }
 
   private void restoreExpandedState(@NotNull Set<String> expandedState) {


### PR DESCRIPTION
# Description of the PR

+ It was annoying when the selected item gets unselected when the tree is updating. Now assistants can download submissions while it's updating

+ Closes #758 

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [ ] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [ ] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [ ] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
