### PR TITLE
Cancel tutorial on project close

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/task/IntelliJComponentPresenterBase.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/task/IntelliJComponentPresenterBase.java
@@ -10,23 +10,29 @@ import fi.aalto.cs.apluscourses.model.task.ComponentPresenter;
 import fi.aalto.cs.apluscourses.ui.ideactivities.ComponentDatabase;
 import fi.aalto.cs.apluscourses.ui.ideactivities.GenericHighlighter;
 import fi.aalto.cs.apluscourses.ui.ideactivities.OverlayPane;
+import fi.aalto.cs.apluscourses.utils.APlusLogger;
 import java.util.Timer;
 import java.util.TimerTask;
 import javax.swing.Action;
 import javax.swing.JOptionPane;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
 
 public abstract class IntelliJComponentPresenterBase implements ComponentPresenter {
 
+  private static final Logger logger = APlusLogger.logger;
+
   public static final int REFRESH_INTERVAL = 1000;
   private final Timer timer;
+
   private final @Nullable String instruction;
   private final @Nullable String info;
   protected final @NotNull Project project;
   private final @NotNull Action @NotNull [] actions;
-  private OverlayPane overlayPane;
   private volatile CancelHandler cancelHandler; //NOSONAR
+
+  private OverlayPane overlayPane;
   private boolean tryingToShow = false;
 
   /**
@@ -129,6 +135,12 @@ public abstract class IntelliJComponentPresenterBase implements ComponentPresent
     public void run() {
       ApplicationManager.getApplication()
           .invokeLater(() -> {
+            if (project.isDisposed()) {
+              logger.info("Tutorial cancelled due to project closing");
+              cancelHandler.onForceCancel();
+              return;
+            }
+
             var progressButton = ComponentDatabase.getProgressButton();
             var progressButtonHighlighted = overlayPane != null
                 && progressButton != null

--- a/src/main/java/fi/aalto/cs/apluscourses/model/task/CancelHandler.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/task/CancelHandler.java
@@ -2,4 +2,6 @@ package fi.aalto.cs.apluscourses.model.task;
 
 public interface CancelHandler {
   void onCancel();
+
+  void onForceCancel();
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/task/Task.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/task/Task.java
@@ -143,6 +143,11 @@ public class Task implements CancelHandler, ListenerCallback {
     notifyObservers(Observer::onCancelled);
   }
 
+  @Override
+  public void onForceCancel() {
+    notifyObservers(Observer::onForceCancelled);
+  }
+
   protected static String @NotNull [] parseAssert(@Nullable JSONArray jsonObject) {
     return jsonObject == null ? new String[0]
         : JsonUtil.parseArray(jsonObject, JSONArray::getString,
@@ -178,6 +183,8 @@ public class Task implements CancelHandler, ListenerCallback {
 
   public interface Observer {
     void onCancelled();
+
+    void onForceCancelled();
 
     void onAutoCompleted();
 

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/ideactivities/TutorialViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/ideactivities/TutorialViewModel.java
@@ -82,6 +82,11 @@ public class TutorialViewModel implements Task.Observer {
   }
 
   @Override
+  public void onForceCancelled() {
+    cancelTutorial(); // does not ask for confirmation
+  }
+
+  @Override
   public void onAutoCompleted() {
     taskNotifier.notifyAlreadyEndTask(tutorialExercise.getTutorial().getTasks().indexOf(currentTask),
         currentTask.getInstruction());


### PR DESCRIPTION
# Description of the PR
Force-cancels the tutorial when the IntelliJ project is closed (IDE exiting, project manually closed, project switched to some other one...)
If the tutorial is not cancelled when the project is closed, two bad things happen:
1. exceptions are continuously thrown (com.intellij.serviceContainer.AlreadyDisposedException)
2. if another project is then opened, the tutorial might incorrectly start affecting that project

Why I didn't use ProjectManagerListener: I'm not sure in which thread the ProjectManagerListener's callbacks run. However, I want the "project disposed check" to run in the EDT before `highlightInternal()` executes, because then there's no chance of any race condition (project closed while something is being highlighted). The `TaskRefresher::run()` is perfect for this case.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [X] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
