### PR TITLE
Fix unit tests

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/utils/APlusLogger.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/APlusLogger.java
@@ -8,5 +8,5 @@ public class APlusLogger {
 
   }
 
-  public static final Logger logger = LoggerFactory.getLogger("A+ Courses " + BuildInfo.INSTANCE.pluginVersion);
+  public static final Logger logger = LoggerFactory.getLogger("A+ Courses");
 }


### PR DESCRIPTION
# Description of the PR
Removes the version from the plugin's log prefix. The version there is causing two issues:
1. Unit tests fail because BuildInfo is accessed, which shouldn't be done inside tests
2. In case something goes wrong in the BuildInfo constructor, the logger is invoked. This causes the version to be fetched through `BuildInfo.INSTANCE`, which calls the BuildInfo constructor and leads to a stack overflow.

In the end, we don't need that version anyway - PluginManager lists the plugin version in another entry:
```
2021-10-07 22:29:39,736 [    547]   INFO - llij.ide.plugins.PluginManager - Loaded custom plugins: Scala (2021.2.22), A+ Courses (3.2)
```

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [X] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
