### PR TITLE
Store student list for a session only

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/SelectStudentDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/SelectStudentDialog.java
@@ -106,7 +106,7 @@ public class SelectStudentDialog extends OurDialogWrapper {
       Executors.newSingleThreadExecutor().submit(() -> {
         try {
           var students = course.getExerciseDataSource()
-              .getStudents(course, auth, CachePreferences.GET_NEW_AND_KEEP);
+              .getStudents(course, auth, CachePreferences.FOR_THIS_SESSION_ONLY);
           SwingUtilities.invokeLater(() -> {
             viewModel.setStudents(students);
             studentList.setPaintBusy(false);


### PR DESCRIPTION
# Description of the PR

+ The list of students is cached in RAM only, not in a JSON file. Previously, we implemented in-RAM caching of API responses but, apparently, forgot to put it into use here. 

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [ ] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [ ] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [ ] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
