### PR TITLE
Add difficulty field to exercises

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/DummyExercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/DummyExercise.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.model;
 
 import java.util.OptionalLong;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 
 public class DummyExercise extends Exercise {
@@ -14,8 +15,9 @@ public class DummyExercise extends Exercise {
                        @NotNull String htmlUrl,
                        @NotNull SubmissionInfo submissionInfo,
                        int maxPoints,
-                       int maxSubmissions) {
-    super(id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions, OptionalLong.empty());
+                       int maxSubmissions,
+                       @Nullable String difficulty) {
+    super(id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions, OptionalLong.empty(), difficulty);
   }
 
   /**
@@ -31,9 +33,11 @@ public class DummyExercise extends Exercise {
     int maxPoints = jsonObject.getInt("max_points");
     int maxSubmissions = jsonObject.getInt("max_submissions");
 
+    String difficulty = jsonObject.optString("difficulty");
+
     var submissionInfo = SubmissionInfo.fromJsonObject(jsonObject);
 
-    return new DummyExercise(id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions);
+    return new DummyExercise(id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions, difficulty);
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -31,6 +31,9 @@ public class Exercise implements Browsable {
   private final int maxSubmissions;
 
   @NotNull
+  private final String difficulty;
+
+  @NotNull
   private final OptionalLong bestSubmissionId;
 
   /**
@@ -49,7 +52,8 @@ public class Exercise implements Browsable {
                   @NotNull SubmissionInfo submissionInfo,
                   int maxPoints,
                   int maxSubmissions,
-                  @NotNull OptionalLong bestSubmissionId) {
+                  @NotNull OptionalLong bestSubmissionId,
+                  @Nullable String difficulty) {
     this.id = id;
     this.name = name;
     this.htmlUrl = htmlUrl;
@@ -57,6 +61,7 @@ public class Exercise implements Browsable {
     this.maxPoints = maxPoints;
     this.maxSubmissions = maxSubmissions;
     this.bestSubmissionId = bestSubmissionId;
+    this.difficulty = difficulty == null ? "" : difficulty;
   }
 
   /**
@@ -79,6 +84,7 @@ public class Exercise implements Browsable {
     var bestSubmissionId = points.getBestSubmissionIds().get(id);
     int maxPoints = jsonObject.getInt("max_points");
     int maxSubmissions = jsonObject.getInt("max_submissions");
+    String difficulty = jsonObject.optString("difficulty");
 
     var submissionInfo = SubmissionInfo.fromJsonObject(jsonObject);
 
@@ -86,10 +92,11 @@ public class Exercise implements Browsable {
     var optionalBestSubmission = bestSubmissionId == null ? OptionalLong.empty()
         : OptionalLong.of(bestSubmissionId);
     if (tutorial == null) {
-      return new Exercise(id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions, optionalBestSubmission);
+      return new Exercise(
+          id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions, optionalBestSubmission, difficulty);
     } else {
       return new TutorialExercise(
-          id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions, optionalBestSubmission, tutorial);
+          id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions, optionalBestSubmission, difficulty, tutorial);
     }
   }
 
@@ -100,6 +107,11 @@ public class Exercise implements Browsable {
   @NotNull
   public String getName() {
     return name;
+  }
+
+  @NotNull
+  public String getDifficulty() {
+    return difficulty;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -175,7 +175,7 @@ public class Exercise implements Browsable {
   }
 
   public boolean isOptional() {
-    return maxSubmissions == 0 && maxPoints == 0;
+    return difficulty.equals("training") || difficulty.equals("challenge");
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/model/TutorialExercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/TutorialExercise.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.model;
 
 import java.util.OptionalLong;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class TutorialExercise extends Exercise {
 
@@ -17,8 +18,9 @@ public class TutorialExercise extends Exercise {
                           int maxPoints,
                           int maxSubmissions,
                           @NotNull OptionalLong bestSubmissionId,
+                          @Nullable String difficulty,
                           @NotNull Tutorial tutorial) {
-    super(id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions, bestSubmissionId);
+    super(id, name, htmlUrl, submissionInfo, maxPoints, maxSubmissions, bestSubmissionId, difficulty);
     this.tutorial = tutorial;
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
@@ -69,7 +69,7 @@ public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> impleme
       return Status.IN_GRADING;
     } else if (exercise instanceof TutorialExercise) {
       return Status.TUTORIAL;
-    } else if (exercise.getDifficulty().equals("training") || exercise.getDifficulty().equals("challenge")) {
+    } else if (exercise.isOptional()) {
       return Status.OPTIONAL_PRACTICE;
     } else if (exercise.getSubmissionResults().isEmpty()) {
       return Status.NO_SUBMISSIONS;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
 
 public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> implements Searchable {
 
+  private static final String TRAINING_DIFFICULTY_ID = "training";
+
   /**
    * Construct a view model corresponding to the given exercise.
    */
@@ -69,7 +71,7 @@ public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> impleme
       return Status.IN_GRADING;
     } else if (exercise instanceof TutorialExercise) {
       return Status.TUTORIAL;
-    } else if (exercise.getDifficulty().equals("training")) { // O1 specific
+    } else if (exercise.getDifficulty().equals(TRAINING_DIFFICULTY_ID)) { // O1 specific
       return Status.OPTIONAL_PRACTICE;
     } else if (exercise.getSubmissionResults().isEmpty()) {
       return Status.NO_SUBMISSIONS;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
@@ -12,8 +12,6 @@ import org.jetbrains.annotations.NotNull;
 
 public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> implements Searchable {
 
-  private static final String TRAINING_DIFFICULTY_ID = "training";
-
   /**
    * Construct a view model corresponding to the given exercise.
    */
@@ -71,7 +69,7 @@ public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> impleme
       return Status.IN_GRADING;
     } else if (exercise instanceof TutorialExercise) {
       return Status.TUTORIAL;
-    } else if (exercise.getDifficulty().equals(TRAINING_DIFFICULTY_ID)) { // O1 specific
+    } else if (exercise.getDifficulty().equals("training") || exercise.getDifficulty().equals("challenge")) {
       return Status.OPTIONAL_PRACTICE;
     } else if (exercise.getSubmissionResults().isEmpty()) {
       return Status.NO_SUBMISSIONS;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
@@ -69,7 +69,7 @@ public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> impleme
       return Status.IN_GRADING;
     } else if (exercise instanceof TutorialExercise) {
       return Status.TUTORIAL;
-    } else if (exercise.getMaxSubmissions() == 0 && exercise.getMaxPoints() == 0) {
+    } else if (exercise.getDifficulty().equals("training")) { // O1 specific
       return Status.OPTIONAL_PRACTICE;
     } else if (exercise.getSubmissionResults().isEmpty()) {
       return Status.NO_SUBMISSIONS;

--- a/src/test/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSourceTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSourceTest.java
@@ -77,7 +77,7 @@ public class APlusExerciseDataSourceTest {
 
     var info = new SubmissionInfo(Collections.singletonMap("fi", List.of(subFile0, subFile1)));
 
-    Exercise exercise = new Exercise(71, "newex", "https://example.com", info, 0, 0, OptionalLong.empty());
+    Exercise exercise = new Exercise(71, "newex", "https://example.com", info, 0, 0, OptionalLong.empty(), null);
 
     Group group = new Group(435, new ArrayList<>());
 

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenItemActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenItemActionTest.java
@@ -65,7 +65,7 @@ public class OpenItemActionTest {
   @Test
   public void testOpenItemActionSubmission() throws Exception {
     var info = new SubmissionInfo(Collections.emptyMap());
-    exercise = new Exercise(223, "TestEx", "http://example.com", info, 1, 10, OptionalLong.empty());
+    exercise = new Exercise(223, "TestEx", "http://example.com", info, 1, 10, OptionalLong.empty(), null);
     submissionResult
         = new SubmissionResult(1, 0, 0.0, SubmissionResult.Status.GRADED, exercise);
     setUp(new SubmissionResultViewModel(submissionResult, 1));
@@ -85,7 +85,7 @@ public class OpenItemActionTest {
   @Test
   public void testOpenItemActionExercise() throws Exception {
     var info = new SubmissionInfo(Collections.emptyMap());
-    exercise = new Exercise(223, "TestEx", "http://example.com", info, 1, 10, OptionalLong.empty());
+    exercise = new Exercise(223, "TestEx", "http://example.com", info, 1, 10, OptionalLong.empty(), null);
     setUp(new ExerciseViewModel(exercise));
     OpenItemAction action = new OpenItemAction(
         mainViewModelProvider,
@@ -120,7 +120,7 @@ public class OpenItemActionTest {
   @Test
   public void testErrorNotification() throws URISyntaxException {
     var info = new SubmissionInfo(Collections.emptyMap());
-    exercise = new Exercise(223, "TestEx", "http://example.com", info, 1, 10, OptionalLong.empty());
+    exercise = new Exercise(223, "TestEx", "http://example.com", info, 1, 10, OptionalLong.empty(), null);
     submissionResult
         = new SubmissionResult(1, 0, 0.0, SubmissionResult.Status.GRADED, exercise);
     setUp(new SubmissionResultViewModel(submissionResult, 1));

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionNotificationActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/OpenSubmissionNotificationActionTest.java
@@ -42,7 +42,7 @@ public class OpenSubmissionNotificationActionTest {
     doReturn(mock(Project.class)).when(event).getProject();
     var info = new SubmissionInfo(Collections.emptyMap());
     submissionResult = new SubmissionResult(1, 0, 0.0, SubmissionResult.Status.GRADED,
-        new Exercise(1, "Ex", "http://example.com", info, 5, 10, OptionalLong.empty()));
+        new Exercise(1, "Ex", "http://example.com", info, 5, 10, OptionalLong.empty(), null));
     notification = mock(Notification.class);
     notifier = mock(Notifier.class);
     submissionRenderer = mock(UrlRenderer.class);

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -127,7 +127,7 @@ public class SubmitExerciseActionTest {
     String language = "fi";
     submissionInfo = new SubmissionInfo(Map.of(language, Collections.singletonList(file)));
     exercise = new Exercise(
-        exerciseId, "Test exercise", "http://localhost:10000", submissionInfo, 0, 0, OptionalLong.empty());
+        exerciseId, "Test exercise", "http://localhost:10000", submissionInfo, 0, 0, OptionalLong.empty(), null);
     group = new Group(124, Collections.singletonList("Only you"));
     groups = Collections.singletonList(group);
     exerciseGroup = new ExerciseGroup(0, "Test EG", "", true, List.of(), List.of());
@@ -305,7 +305,7 @@ public class SubmitExerciseActionTest {
   @Test
   public void testNotifiesExerciseNotSubmittable() throws IOException {
     var exercise = new Exercise(0, "", "", new SubmissionInfo(Map.of()), 0, 0,
-        OptionalLong.empty());
+        OptionalLong.empty(), null);
     var exerciseGroup = new ExerciseGroup(0, "", "", true, List.of(), List.of());
     exerciseGroup.addExercise(exercise);
     mainViewModel.exercisesViewModel.set(

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotificationTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotificationTest.java
@@ -19,7 +19,7 @@ public class FeedbackAvailableNotificationTest {
   @Test
   public void testFeedbackAvailableNotificationTest() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    var exercise = new Exercise(123, "Test Exercise", "https://example.com", info, 5, 10, OptionalLong.empty());
+    var exercise = new Exercise(123, "Test Exercise", "https://example.com", info, 5, 10, OptionalLong.empty(), null);
     SubmissionResult result
         = new SubmissionResult(0, 0, 0.0, SubmissionResult.Status.GRADED, exercise);
     Notification notification = new FeedbackAvailableNotification(result, exercise);

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseGroupTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseGroupTest.java
@@ -24,8 +24,8 @@ public class ExerciseGroupTest {
   @Test
   public void testExerciseGroup() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    Exercise exercise1 = new Exercise(123, "name1", "https://example.com", info, 0, 0, OptionalLong.empty());
-    Exercise exercise2 = new Exercise(456, "name2", "https://example.org", info, 0, 0, OptionalLong.empty());
+    Exercise exercise1 = new Exercise(123, "name1", "https://example.com", info, 0, 0, OptionalLong.empty(), null);
+    Exercise exercise2 = new Exercise(456, "name2", "https://example.org", info, 0, 0, OptionalLong.empty(), null);
 
     ExerciseGroup group = new ExerciseGroup(22, "group", "https://example.fi", true, List.of(), List.of());
     group.addExercise(exercise1);

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
@@ -21,7 +21,7 @@ public class ExerciseTest {
   @Test
   public void testExercise() {
     var info = new SubmissionInfo(Map.of("de", List.of(new SubmittableFile("f1", "a"))));
-    Exercise exercise = new Exercise(987, "def", "http://localhost:4444", info, 15, 10, OptionalLong.empty());
+    Exercise exercise = new Exercise(987, "def", "http://localhost:4444", info, 15, 10, OptionalLong.empty(), null);
 
     assertEquals("The ID is the same as the one given to the constructor",
         987L, exercise.getId());
@@ -33,6 +33,8 @@ public class ExerciseTest {
         15, exercise.getMaxPoints());
     assertEquals("The maximum submissions are the same as those given to the constructor",
         10, exercise.getMaxSubmissions());
+    assertEquals("The difficulty should be converted from null to an empty string",
+        "", exercise.getDifficulty());
     assertTrue("The exercise submittability depends on the submission info parameter",
         exercise.isSubmittable());
     assertNull("The submission ID is the one given to the constructor",
@@ -56,6 +58,7 @@ public class ExerciseTest {
   private static final String HTML_KEY = "html_url";
   private static final String MAX_POINTS_KEY = "max_points";
   private static final String MAX_SUBMISSIONS_KEY = "max_submissions";
+  private static final String DIFFICULTY_KEY = "difficulty";
 
   @Test
   public void testExerciseFromJsonObject() {
@@ -65,6 +68,7 @@ public class ExerciseTest {
         .put(HTML_KEY, "http://localhost:1000")
         .put(MAX_POINTS_KEY, 99)
         .put(MAX_SUBMISSIONS_KEY, 5)
+        .put(DIFFICULTY_KEY, "ha")
         .put("additional key", "which shouldn't cause errors");
 
     Exercise exercise = Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptyMap());
@@ -83,6 +87,8 @@ public class ExerciseTest {
         99, exercise.getMaxPoints());
     assertEquals("The max submissions is the same as the one in the JSON object",
         5, exercise.getMaxSubmissions());
+    assertEquals("The difficulty is the same as the one in the JSON object",
+        "ha", exercise.getDifficulty());
     assertFalse("The missing exercise_info makes the exercise unsubmittable",
         exercise.isSubmittable());
     assertFalse("The exercise is In Grading (default value)", exercise.isInGrading());
@@ -135,9 +141,9 @@ public class ExerciseTest {
   @Test
   public void testEquals() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    var exercise = new Exercise(7, "oneEx", "http://localhost:1111", info, 0, 0, OptionalLong.empty());
-    var sameExercise = new Exercise(7, "twoEx", "http://localhost:2222", info, 3, 4, OptionalLong.empty());
-    var otherExercise = new Exercise(4, "oneEx", "http://localhost:2222", info, 2, 1, OptionalLong.empty());
+    var exercise = new Exercise(7, "oneEx", "http://localhost:1111", info, 0, 0, OptionalLong.empty(), "A");
+    var sameExercise = new Exercise(7, "twoEx", "http://localhost:2222", info, 3, 4, OptionalLong.empty(), "B");
+    var otherExercise = new Exercise(4, "oneEx", "http://localhost:2222", info, 2, 1, OptionalLong.empty(), "A");
 
     assertEquals(exercise, sameExercise);
     assertEquals(exercise.hashCode(), sameExercise.hashCode());
@@ -149,9 +155,9 @@ public class ExerciseTest {
   public void testIsCompleted() {
     var info = new SubmissionInfo(Collections.emptyMap());
     Exercise optionalNotSubmitted
-        = new Exercise(1, "optionalNotSubmitted", "http://localhost:1111", info, 0, 0, OptionalLong.empty());
+        = new Exercise(1, "optionalNotSubmitted", "http://localhost:1111", info, 0, 0, OptionalLong.empty(), null);
     Exercise optionalSubmitted
-        = new Exercise(2, "optionalSubmitted", "http://localhost:1111", info, 0, 0, OptionalLong.empty());
+        = new Exercise(2, "optionalSubmitted", "http://localhost:1111", info, 0, 0, OptionalLong.empty(), null);
     optionalSubmitted.addSubmissionResult(new SubmissionResult(
         1, 0, 0.0, SubmissionResult.Status.GRADED, optionalSubmitted));
 
@@ -161,13 +167,13 @@ public class ExerciseTest {
         optionalSubmitted.isCompleted());
 
     Exercise noSubmissions
-        = new Exercise(3, "noSubmissions", "http://localhost:1111", info, 5, 10, OptionalLong.empty());
+        = new Exercise(3, "noSubmissions", "http://localhost:1111", info, 5, 10, OptionalLong.empty(), null);
     Exercise failed
-        = new Exercise(4, "failed", "http://localhost:1111", info, 5, 10, OptionalLong.of(1));
+        = new Exercise(4, "failed", "http://localhost:1111", info, 5, 10, OptionalLong.of(1), null);
     failed.addSubmissionResult(new SubmissionResult(
         1, 3, 0.0, SubmissionResult.Status.GRADED, failed));
 
-    Exercise completed = new Exercise(5, "completed", "http://localhost:1111", info, 5, 10, OptionalLong.of(1));
+    Exercise completed = new Exercise(5, "completed", "http://localhost:1111", info, 5, 10, OptionalLong.of(1), null);
     completed.addSubmissionResult(new SubmissionResult(
         1, 5, 0.0, SubmissionResult.Status.GRADED, completed));
 
@@ -183,11 +189,11 @@ public class ExerciseTest {
   @Test
   public void testIsOptional() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    Exercise optional = new Exercise(1, "optional", "http://localhost:1111", info, 0, 0, OptionalLong.empty());
+    Exercise optional = new Exercise(1, "optional", "http://localhost:1111", info, 0, 0, OptionalLong.empty(), null);
     assertTrue("Assignment is optional",
         optional.isOptional());
 
-    Exercise notOptional = new Exercise(2, "notOptional", "http://localhost:1111", info, 5, 10, OptionalLong.empty());
+    Exercise notOptional = new Exercise(2, "notOptional", "http://localhost:1111", info, 5, 10, OptionalLong.empty(), null);
     assertFalse("Assignment isn't optional",
         notOptional.isOptional());
   }
@@ -195,7 +201,7 @@ public class ExerciseTest {
   @Test
   public void testIsInGrading() {
     var exercise = new Exercise(
-        1, "", "http://localhost:1", new SubmissionInfo(Collections.emptyMap()), 10, 10, OptionalLong.empty());
+        1, "", "http://localhost:1", new SubmissionInfo(Collections.emptyMap()), 10, 10, OptionalLong.empty(), null);
     exercise.addSubmissionResult(new SubmissionResult(
         0, 0, 0.0, SubmissionResult.Status.UNOFFICIAL, exercise
     ));

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
@@ -155,9 +155,9 @@ public class ExerciseTest {
   public void testIsCompleted() {
     var info = new SubmissionInfo(Collections.emptyMap());
     Exercise optionalNotSubmitted
-        = new Exercise(1, "optionalNotSubmitted", "http://localhost:1111", info, 0, 0, OptionalLong.empty(), null);
+        = new Exercise(1, "optionalNotSubmitted", "http://localhost:1111", info, 1, 10, OptionalLong.empty(), "training");
     Exercise optionalSubmitted
-        = new Exercise(2, "optionalSubmitted", "http://localhost:1111", info, 0, 0, OptionalLong.empty(), null);
+        = new Exercise(2, "optionalSubmitted", "http://localhost:1111", info, 1, 10, OptionalLong.empty(), "training");
     optionalSubmitted.addSubmissionResult(new SubmissionResult(
         1, 0, 0.0, SubmissionResult.Status.GRADED, optionalSubmitted));
 
@@ -189,11 +189,11 @@ public class ExerciseTest {
   @Test
   public void testIsOptional() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    Exercise optional = new Exercise(1, "optional", "http://localhost:1111", info, 0, 0, OptionalLong.empty(), null);
+    Exercise optional = new Exercise(1, "optional", "http://localhost:1111", info, 1, 10, OptionalLong.empty(), "training");
     assertTrue("Assignment is optional",
         optional.isOptional());
 
-    Exercise notOptional = new Exercise(2, "notOptional", "http://localhost:1111", info, 5, 10, OptionalLong.empty(), null);
+    Exercise notOptional = new Exercise(2, "notOptional", "http://localhost:1111", info, 1, 10, OptionalLong.empty(), "B");
     assertFalse("Assignment isn't optional",
         notOptional.isOptional());
   }

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -70,7 +70,7 @@ public class ModelExtensions {
                                 @NotNull Authentication authentication,
                                 @NotNull CachePreference cachePreference) {
       return new Exercise(1, "lol", "http://example.com",
-          new SubmissionInfo(Collections.emptyMap()), 20, 10, OptionalLong.empty()
+          new SubmissionInfo(Collections.emptyMap()), 20, 10, OptionalLong.empty(), null
       );
     }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionResultTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionResultTest.java
@@ -14,7 +14,7 @@ public class SubmissionResultTest {
   @Test
   public void testSubmissionResult() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    Exercise exercise = new Exercise(444L, "someEx", "http://example.com/", info, 20, 10, OptionalLong.of(123L));
+    Exercise exercise = new Exercise(444L, "someEx", "http://example.com/", info, 20, 10, OptionalLong.of(123L), null);
     SubmissionResult submissionResult
         = new SubmissionResult(123L, 13, 0.5, SubmissionResult.Status.GRADED, exercise);
     exercise.addSubmissionResult(submissionResult);
@@ -36,7 +36,7 @@ public class SubmissionResultTest {
   @Test
   public void testFromJsonObject() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    Exercise exercise = new Exercise(555L, "myEx", "https://example.org/", info, 20, 10, OptionalLong.of(234));
+    Exercise exercise = new Exercise(555L, "myEx", "https://example.org/", info, 20, 10, OptionalLong.of(234), null);
     JSONObject jsonObject = new JSONObject()
         .put("id", 234)
         .put("grade", 30)

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdaterTest.java
@@ -72,7 +72,7 @@ public class SubmissionStatusUpdaterTest {
         mock(Authentication.class),
         notifier,
         "http://localhost:1000",
-        new Exercise(789, "Cool Exercise Name", "http://example.com", info, 5, 10, OptionalLong.empty()),
+        new Exercise(789, "Cool Exercise Name", "http://example.com", info, 5, 10, OptionalLong.empty(), null),
         25L, // 0.025 second interval
         0L, // don't increment the interval at all
         10000L // 10 second time limit, which shouldn't be reached
@@ -94,7 +94,7 @@ public class SubmissionStatusUpdaterTest {
         mock(Authentication.class),
         notifier,
         "http://localhost:1000",
-        new Exercise(789, "Cool Exercise Name", "http://example.com", info, 5, 10, OptionalLong.empty()),
+        new Exercise(789, "Cool Exercise Name", "http://example.com", info, 5, 10, OptionalLong.empty(), null),
         25L, // 0.025 second interval
         0L, // don't increment the interval at all
         200L // 0.2 second time limit, should update at most 8 times

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionTest.java
@@ -22,7 +22,7 @@ public class SubmissionTest {
     var fileB = new SubmittableFile("keyB", "fileB");
     var language = "de";
     var info = new SubmissionInfo(Collections.singletonMap(language, List.of(fileA, fileB)));
-    Exercise exercise = new Exercise(85678, "ex", "http://localhost:1000", info, 0, 0, OptionalLong.empty());
+    Exercise exercise = new Exercise(85678, "ex", "http://localhost:1000", info, 0, 0, OptionalLong.empty(), null);
     Map<String, Path> files = new HashMap<>();
     files.put("fileA", Paths.get("some.file"));
     files.put("fileB", Paths.get("other.file"));

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
@@ -37,15 +37,15 @@ public class ExerciseGroupViewModelTest {
   public void testSortsExercises1() {
     var info = new SubmissionInfo(Collections.emptyMap());
     Exercise first = new Exercise(424, "Assignment 3",
-        "http://localhost:1000/w10/ch02/w10_ch02_03/", info, 0, 0, OptionalLong.empty());
+        "http://localhost:1000/w10/ch02/w10_ch02_03/", info, 0, 0, OptionalLong.empty(), null);
     Exercise second = new Exercise(325, "Feedback",
-        "http://localhost:1000/w10/ch02/w10_ch02_feedback/", info, 0, 0, OptionalLong.empty());
+        "http://localhost:1000/w10/ch02/w10_ch02_feedback/", info, 0, 0, OptionalLong.empty(), null);
     Exercise third = new Exercise(195, "Assignment 9",
-        "http://localhost:1000/w10/ch03/w10_ch03_9/", info, 0, 0, OptionalLong.empty());
+        "http://localhost:1000/w10/ch03/w10_ch03_9/", info, 0, 0, OptionalLong.empty(), null);
     Exercise fourth = new Exercise(282, "Assignment 10",
-        "http://localhost:1000/w10/ch04/w10_ch03_10/", info, 0, 0, OptionalLong.empty());
+        "http://localhost:1000/w10/ch04/w10_ch03_10/", info, 0, 0, OptionalLong.empty(), null);
     Exercise fifth = new Exercise(908, "Assignment 1",
-        "http://localhost:1000/w12/ch01/w12_ch01_1/", info, 0, 0, OptionalLong.empty());
+        "http://localhost:1000/w12/ch01/w12_ch01_1/", info, 0, 0, OptionalLong.empty(), null);
 
 
     ExerciseGroup group = new ExerciseGroup(5, "", "", true, List.of(),
@@ -69,11 +69,11 @@ public class ExerciseGroupViewModelTest {
   public void testSortsExercises2() {
     var info = new SubmissionInfo(Collections.emptyMap());
     Exercise first = new Exercise(424, "Assignment 3",
-        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_1/", info, 0, 0, OptionalLong.empty());
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_1/", info, 0, 0, OptionalLong.empty(), null);
     Exercise second = new Exercise(325, "Feedback",
-        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_10/", info, 0, 0, OptionalLong.empty());
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_10/", info, 0, 0, OptionalLong.empty(), null);
     Exercise third = new Exercise(195, "Assignment 9",
-        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15B_osa01_1/", info, 0, 0, OptionalLong.empty());
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15B_osa01_1/", info, 0, 0, OptionalLong.empty(), null);
 
 
     ExerciseGroup group = new ExerciseGroup(5, "", "", true, List.of(),
@@ -97,7 +97,7 @@ public class ExerciseGroupViewModelTest {
   public void testFilterVisibility() throws InterruptedException {
     var info = new SubmissionInfo(Collections.emptyMap());
     Exercise exercise = new Exercise(424, "Assignment 3",
-        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_1/", info, 0, 0, OptionalLong.empty());
+        "http://localhost:1000/studio_2/k2021dev/k15A/osa01/k15A_osa01_1/", info, 0, 0, OptionalLong.empty(), null);
 
     ExerciseGroup group = new ExerciseGroup(5, "", "", true, List.of(), List.of());
     group.addExercise(exercise);

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
@@ -16,11 +16,12 @@ public class ExerciseViewModelTest {
   public void testGetPresentableName() {
     var info = new SubmissionInfo(Collections.emptyMap());
 
-    Exercise exercise1
-        = new Exercise(123, "|en:Assignment|fi:Tehtava|", "http://localhost:1000", info, 0, 0, OptionalLong.empty());
+    Exercise exercise1 = new Exercise(
+        123, "|en:Assignment|fi:Tehtava|", "http://localhost:1000", info, 0, 0, OptionalLong.empty(), null);
     ExerciseViewModel viewModel1 = new ExerciseViewModel(exercise1);
 
-    Exercise exercise2 = new Exercise(234, "Just a name", "http://localhost:2000", info, 0, 0, OptionalLong.empty());
+    Exercise exercise2 = new Exercise(
+        234, "Just a name", "http://localhost:2000", info, 0, 0, OptionalLong.empty(), null);
     ExerciseViewModel viewModel2 = new ExerciseViewModel(exercise2);
 
     Assert.assertEquals("getPresentableName returns the English name of the exercise",
@@ -35,8 +36,8 @@ public class ExerciseViewModelTest {
         Collections.singletonMap("fi", List.of(new SubmittableFile("file1", "abc")))
     );
     var info2 = new SubmissionInfo(Collections.emptyMap());
-    Exercise submittable = new Exercise(0, "", "http://abc.org", info1, 0, 0, OptionalLong.empty());
-    Exercise notSubmittable = new Exercise(0, "", "http://def.org", info2, 0, 0, OptionalLong.empty());
+    Exercise submittable = new Exercise(0, "", "http://abc.org", info1, 0, 0, OptionalLong.empty(), null);
+    Exercise notSubmittable = new Exercise(0, "", "http://def.org", info2, 0, 0, OptionalLong.empty(), null);
     ExerciseViewModel viewModel1 = new ExerciseViewModel(submittable);
     ExerciseViewModel viewModel2 = new ExerciseViewModel(notSubmittable);
 
@@ -49,19 +50,19 @@ public class ExerciseViewModelTest {
     var info = new SubmissionInfo(Collections.emptyMap());
     String htmlUrl = "http://localhost:6000";
     SubmissionResult.Status resultStatus = SubmissionResult.Status.GRADED;
-    Exercise training = new Exercise(0, "", htmlUrl, info, 0, 0, OptionalLong.empty());
+    Exercise training = new Exercise(0, "", htmlUrl, info, 1, 10, OptionalLong.empty(), "training");
     training.addSubmissionResult(new SubmissionResult(1L, 0, 0.0, resultStatus, training));
-    Exercise noPoints = new Exercise(0, "", htmlUrl, info, 10, 10, OptionalLong.empty());
+    Exercise noPoints = new Exercise(0, "", htmlUrl, info, 10, 10, OptionalLong.empty(), null);
     noPoints.addSubmissionResult(new SubmissionResult(1L, 0, 0.0, resultStatus, noPoints));
-    Exercise partialPoints = new Exercise(0, "", htmlUrl, info, 10, 10, OptionalLong.of(1L));
+    Exercise partialPoints = new Exercise(0, "", htmlUrl, info, 10, 10, OptionalLong.of(1L), null);
     var partialPointsSubmissionRes = new SubmissionResult(1L, 5, 0.0, SubmissionResult.Status.GRADED, partialPoints);
     partialPoints.addSubmissionResult(partialPointsSubmissionRes);
     partialPoints.addSubmissionResult(new SubmissionResult(1L, 5, 0.0, resultStatus, partialPoints));
-    Exercise fullPoints = new Exercise(0, "", htmlUrl, info, 10, 10, OptionalLong.of(2L));
+    Exercise fullPoints = new Exercise(0, "", htmlUrl, info, 10, 10, OptionalLong.of(2L), null);
     var fullPointsSubmissionRes = new SubmissionResult(2L, 10, 0.0, SubmissionResult.Status.GRADED, fullPoints);
     fullPoints.addSubmissionResult(fullPointsSubmissionRes);
     fullPoints.addSubmissionResult(new SubmissionResult(1L, 10, 0.0, resultStatus, fullPoints));
-    Exercise noSubmissions = new Exercise(0, "", htmlUrl, info, 10, 10, OptionalLong.empty());
+    Exercise noSubmissions = new Exercise(0, "", htmlUrl, info, 10, 10, OptionalLong.empty(), null);
 
     Assert.assertEquals(ExerciseViewModel.Status.OPTIONAL_PRACTICE,
         new ExerciseViewModel(training).getStatus());
@@ -83,13 +84,13 @@ public class ExerciseViewModelTest {
   @Test
   public void testGetStatusText() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    Exercise exercise1 = new Exercise(0, "", "http://localhost:1212", info, 49, 12, OptionalLong.of(1L));
+    Exercise exercise1 = new Exercise(0, "", "http://localhost:1212", info, 49, 12, OptionalLong.of(1L), null);
     var ex1SubmissionRes = new SubmissionResult(1L, 3, 0.0, SubmissionResult.Status.GRADED, exercise1);
     exercise1.addSubmissionResult(ex1SubmissionRes);
     ExerciseViewModel viewModel1 = new ExerciseViewModel(exercise1);
-    Exercise exercise2 = new Exercise(0, "", "http://localhost:2121", info, 0, 0, OptionalLong.empty());
+    Exercise exercise2 = new Exercise(0, "", "http://localhost:2121", info, 1, 10, OptionalLong.empty(), "training");
     ExerciseViewModel viewModel2 = new ExerciseViewModel(exercise2);
-    Exercise exercise3 = new Exercise(0, "Feedback", "http://localhost:9999", info, 0, 0, OptionalLong.empty());
+    Exercise exercise3 = new Exercise(0, "Feedback", "http://localhost:9999", info, 0, 0, OptionalLong.empty(), null);
     ExerciseViewModel viewModel3 = new ExerciseViewModel(exercise3);
 
     Assert.assertEquals("The status text is correct", "1 of 12, 3/49", viewModel1.getStatusText());
@@ -103,9 +104,9 @@ public class ExerciseViewModelTest {
   public void testGetSearchableString() {
     String name = "Sample name";
     var info = new SubmissionInfo(Collections.emptyMap());
-    Exercise exercise1 = new Exercise(0, name, "http://abc.org", info, 0, 0, OptionalLong.empty());
+    Exercise exercise1 = new Exercise(0, name, "http://abc.org", info, 0, 0, OptionalLong.empty(), null);
     ExerciseViewModel viewModel1 = new ExerciseViewModel(exercise1);
-    Exercise exercise2 = new Exercise(0, "", "http://abc2.org", info, 0, 0, OptionalLong.empty());
+    Exercise exercise2 = new Exercise(0, "", "http://abc2.org", info, 0, 0, OptionalLong.empty(), null);
     ExerciseViewModel viewModel2 = new ExerciseViewModel(exercise2);
 
     Assert.assertEquals(name, viewModel1.getSearchableString());

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionResultViewModelTest.java
@@ -16,7 +16,7 @@ public class SubmissionResultViewModelTest {
   @Test
   public void testSubmissionResultViewModel() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    Exercise exercise = new Exercise(0, "", "", info, 25, 10, OptionalLong.empty());
+    Exercise exercise = new Exercise(0, "", "", info, 25, 10, OptionalLong.empty(), null);
     SubmissionResult submissionResult
         = new SubmissionResult(123L, 15, 0.0, SubmissionResult.Status.WAITING, exercise, new SubmissionFileInfo[0]);
     SubmissionResultViewModel viewModel = new SubmissionResultViewModel(submissionResult, 34);

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
@@ -47,7 +47,7 @@ public class SubmissionViewModelTest {
         = Collections.singletonMap(language, Collections.singletonList(file));
     var submissionInfo = new SubmissionInfo(files);
     Exercise exercise = new Exercise(
-        100, "Exercise", "http://localhost:1000", submissionInfo, 0, 0, OptionalLong.empty());
+        100, "Exercise", "http://localhost:1000", submissionInfo, 0, 0, OptionalLong.empty(), null);
 
     SubmissionViewModel submissionViewModel =
         new SubmissionViewModel(exercise, groups, null, fileMap, language);
@@ -59,7 +59,7 @@ public class SubmissionViewModelTest {
   @Test
   public void testSubmissionNumbers() {
     var info = new SubmissionInfo(Collections.emptyMap());
-    Exercise exercise = new Exercise(1, "ex", "http://localhost:2000", info, 0, 5, OptionalLong.empty());
+    Exercise exercise = new Exercise(1, "ex", "http://localhost:2000", info, 0, 5, OptionalLong.empty(), null);
     IntStream.range(0, 3).forEach(i -> exercise.addSubmissionResult(
         new SubmissionResult(i, 10, 0.0, SubmissionResult.Status.GRADED, exercise)));
 
@@ -92,7 +92,7 @@ public class SubmissionViewModelTest {
 
     // Max submissions 0
     SubmissionViewModel submissionViewModel4 = new SubmissionViewModel(
-        new Exercise(0, "", "", info, 0, 0, OptionalLong.empty()),
+        new Exercise(0, "", "", info, 0, 0, OptionalLong.empty(), null),
         Collections.emptyList(), null, Collections.emptyMap(), "");
     assertEquals("You are about to make submission 1.",
         submissionViewModel4.getSubmissionCountText());
@@ -109,7 +109,7 @@ public class SubmissionViewModelTest {
     files.put("en", List.of(englishFile1, englishFile2));
     files.put("fi", List.of(finnishFile1, finnishFile2));
     var exercise = new Exercise(
-        324, "cool", "http://localhost:1324", new SubmissionInfo(files), 0, 0, OptionalLong.empty());
+        324, "cool", "http://localhost:1324", new SubmissionInfo(files), 0, 0, OptionalLong.empty(), null);
 
     SubmissionViewModel submission = new SubmissionViewModel(
         exercise, Collections.emptyList(), null, Collections.emptyMap(), "fi"
@@ -122,7 +122,7 @@ public class SubmissionViewModelTest {
   @Test
   public void testDefaultGroup() {
     Exercise exercise = new Exercise(
-        1000, "wow", "http://www.fi", new SubmissionInfo(Collections.emptyMap()), 0, 0, OptionalLong.empty());
+        1000, "wow", "http://www.fi", new SubmissionInfo(Collections.emptyMap()), 0, 0, OptionalLong.empty(), null);
     Group group = new Group(1, List.of("Jyrki", "Jorma"));
     List<Group> availableGroups = Collections.singletonList(group);
 

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialogTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialogTest.java
@@ -67,7 +67,7 @@ public class SubmissionDialogTest extends LightIdeaTestCase {
                                               int maxNumberOfSubmissions) {
     var info = new SubmissionInfo(Collections.singletonMap("en", submittableFiles));
     var exercise = new Exercise(
-        1, exerciseName, "http://www.fi", info, 0, maxNumberOfSubmissions, OptionalLong.empty());
+        1, exerciseName, "http://www.fi", info, 0, maxNumberOfSubmissions, OptionalLong.empty(), null);
     IntStream.range(0, numberOfSubmissions).forEach(i -> exercise.addSubmissionResult(
         new SubmissionResult(i, 2, 0.0, SubmissionResult.Status.GRADED, exercise)));
     return new SubmissionViewModel(


### PR DESCRIPTION
# Description of the PR
The exercise difficulty (aka points category, for example "A", "B" or "C" in O1) is now accessible. We will use that to detect optional tasks more reliably.

(Come to think of it, for the O1-specific hotfix we could have just checked for maxPoints == 1 [no other task has this] but we need the difficulty category in the long run anyway)

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>e2e</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [X] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>e2e</b> tests created</li>
        <li>- [X] all <b>e2e</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/intellij-plugin/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
