### PR TITLE
Free-range button label now customizable

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/task/Task.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/task/Task.java
@@ -25,6 +25,7 @@ public class Task implements CancelHandler, ListenerCallback {
   private final @NotNull String action;
   private final @NotNull Arguments actionArguments;
   private final boolean isFreeRange;
+  private final @Nullable String freeRangeLabel; // label of the "next step" button; if null, some default is used
   private final boolean isAlreadyCompleted;
 
   private ActivitiesListener listener;
@@ -43,6 +44,7 @@ public class Task implements CancelHandler, ListenerCallback {
               @NotNull String action,
               @NotNull Arguments actionArguments,
               boolean isFreeRange,
+              @Nullable String freeRangeLabel,
               boolean isAlreadyCompleted) {
     this.instruction = instruction;
     this.info = info;
@@ -52,6 +54,7 @@ public class Task implements CancelHandler, ListenerCallback {
     this.action = action;
     this.actionArguments = actionArguments;
     this.isFreeRange = isFreeRange;
+    this.freeRangeLabel = freeRangeLabel;
     this.isAlreadyCompleted = isAlreadyCompleted;
   }
 
@@ -68,6 +71,7 @@ public class Task implements CancelHandler, ListenerCallback {
         action,
         actionArguments,
         true,
+        getText("ui.tutorial.Task.freeRangeNextTaskButton"),
         true
     );
   }
@@ -110,9 +114,9 @@ public class Task implements CancelHandler, ListenerCallback {
 
       var reaction = new Reaction[0];
       if (isAlreadyCompleted) {
-        reaction = new Reaction[] {new AlreadyCompleteReaction()};
+        reaction = new Reaction[] { new AlreadyCompleteReaction() };
       } else if (isFreeRange) {
-        reaction = new Reaction[] {new ImDoneReaction()};
+        reaction = new Reaction[] { new ImDoneReaction(freeRangeLabel) };
       }
 
       var presenter = activityFactory.createPresenter(componentName, attachPopup ? instruction : null,
@@ -160,6 +164,7 @@ public class Task implements CancelHandler, ListenerCallback {
         jsonObject.getString("action"),
         parseArguments(jsonObject.optJSONObject("actionArguments")),
         jsonObject.optBoolean("freeRange", false),
+        jsonObject.optString("freeRangeLabel", null),
         false);
   }
 
@@ -233,9 +238,15 @@ public class Task implements CancelHandler, ListenerCallback {
 
   private class ImDoneReaction implements Reaction {
 
+    private final @NotNull String labelText;
+
+    public ImDoneReaction(@Nullable String labelText) {
+      this.labelText = labelText == null ? getText("ui.tutorial.Task.freeRangeDefaultButton") : labelText;
+    }
+
     @Override
     public String getLabel() {
-      return "I'm done!";
+      return labelText;
     }
 
     @Override

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -201,6 +201,8 @@ ui.tutorial.TutorialActionGroup.step=Step {0}
 ui.tutorial.TutorialAction.cancelTutorial=Cancel Tutorial
 ui.tutorial.TutorialAction.continueTutorial=Resume
 ui.tutorial.Task.done=(Done)
+ui.tutorial.Task.freeRangeDefaultButton=I'm done!
+ui.tutorial.Task.freeRangeNextTaskButton=Next task
 ui.tutorial.Task.alreadyCompleted=<i>The task is already completed, you can move on to the next task by clicking "Next task".</i><br><br>
 ## Action Tooltip
 intellij.actions.SubmitExerciseAction.waitForAssignments=Waiting for Assignments...


### PR DESCRIPTION
# Description of the PR
The button label for free range tasks that used to always say "I'm done!" now can be customized on a per-task basis

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/aplus-courses/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
