### PR TITLE
Set news tree's row height to variable

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/news/NewsView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/news/NewsView.java
@@ -87,6 +87,7 @@ public class NewsView implements ToolbarPanel {
     title = new JLabel();
     newsTree = new TreeView();
     newsTree.setCellRenderer(new NewsTreeRenderer());
+    newsTree.setRowHeight(-1);
   }
 
   public TreeView getNewsTree() {


### PR DESCRIPTION
# Description of the PR
As the documentation of setRowHeight states "If the specified value is less than or equal to zero, the current cell renderer is queried for each row's height."
In short, if the row height is set to default, the tree calculates all bounds, then throws that away and just uses this constant value.

![obraz](https://user-images.githubusercontent.com/73069541/153845111-d545707e-9eda-4de2-b73e-48571d44c391.png)

TODO: someone test on Linux

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/aplus-courses/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
