### PR TITLE
Simplified constructors for test courses

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-class IntelliJCourse extends Course {
+public class IntelliJCourse extends Course {
 
   @NotNull
   private final APlusProject project;
@@ -44,6 +44,9 @@ class IntelliJCourse extends Course {
 
   private final ExerciseDataSource exerciseDataSource;
 
+  /**
+   * Constructor.
+   */
   public IntelliJCourse(@NotNull String id,
                         @NotNull String name,
                         @NotNull String aplusUrl,
@@ -101,8 +104,7 @@ class IntelliJCourse extends Course {
   @Nullable
   public Component getComponentIfExists(VirtualFile file) {
     Component component = getComponentIfExists(file.getName());
-    Path pathOfTheFile = Paths.get(file.getPath());
-    return component != null && component.getFullPath().equals(pathOfTheFile) ? component : null;
+    return component != null && component.getFullPath().equals(Paths.get(file.getPath())) ? component : null;
   }
 
   @NotNull

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/CourseUpdaterTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/CourseUpdaterTest.java
@@ -1,7 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.model;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
@@ -17,14 +16,12 @@ import fi.aalto.cs.apluscourses.intellij.notifications.NewModulesVersionsNotific
 import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
 import fi.aalto.cs.apluscourses.model.ModelExtensions;
 import fi.aalto.cs.apluscourses.model.Module;
-import fi.aalto.cs.apluscourses.utils.BuildInfo;
 import fi.aalto.cs.apluscourses.utils.Event;
 import fi.aalto.cs.apluscourses.utils.Version;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -60,12 +57,7 @@ class CourseUpdaterTest {
         .fetch(any(URL.class));
     event = mock(Event.class);
     notifier = mock(Notifier.class);
-    var course = new ModelExtensions.TestCourse(
-        "1", "O1", "http://example.com", Collections.emptyList(), Collections.singletonList(module),
-        Collections.emptyList(), Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap(),
-        Collections.emptyList(), Collections.emptyMap(), BuildInfo.INSTANCE.courseVersion,
-        Collections.emptyMap()
-    );
+    var course = new ModelExtensions.TestCourse("1");
     updater = new CourseUpdater(
         mock(CourseProject.class), course, project, courseUrl, configurationFetcher, event, notifier, 50L
     );

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourseTest.java
@@ -1,9 +1,5 @@
 package fi.aalto.cs.apluscourses.intellij.model;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -14,11 +10,9 @@ import fi.aalto.cs.apluscourses.model.Component;
 import fi.aalto.cs.apluscourses.model.Library;
 import fi.aalto.cs.apluscourses.model.ModelExtensions;
 import fi.aalto.cs.apluscourses.model.Module;
-import fi.aalto.cs.apluscourses.utils.BuildInfo;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -37,28 +31,7 @@ class IntelliJCourseTest {
     doReturn(Paths.get("")).when(project).getBasePath();
     when(project.getMessageBus()).thenReturn(mock(MessageBus.class));
     CommonLibraryProvider commonLibraryProvider = new CommonLibraryProvider(project);
-    IntelliJCourse course = new IntelliJCourse(id, name,
-        "http://localhost:1355",
-        Collections.emptyList(),
-        // modules
-        Collections.emptyList(),
-        // libraries
-        Collections.emptyList(),
-        // exerciseModules
-        Collections.emptyMap(),
-        // resourceUrls
-        Collections.emptyMap(),
-        // vmOptions
-        Collections.emptyMap(),
-        // autoInstallComponentNames
-        Collections.emptyList(),
-        // replInitialCommands
-        Collections.emptyMap(),
-        // courseVersion
-        BuildInfo.INSTANCE.courseVersion,
-        project,
-        commonLibraryProvider,
-        Collections.emptyMap());
+    IntelliJCourse course = new ModelExtensions.TestIntelliJCourse(id, name, project, commonLibraryProvider);
     Assertions.assertEquals(id, course.getId());
     Assertions.assertEquals(name, course.getName());
     Assertions.assertSame(project, course.getProject());
@@ -85,28 +58,8 @@ class IntelliJCourseTest {
       }
     };
 
-    IntelliJCourse course = new IntelliJCourse("cool id",
-        "testProject",
-        "https://example.com",
-        Collections.emptyList(),
-        modules,
-        // libraries
-        Collections.emptyList(),
-        // exerciseModules
-        Collections.emptyMap(),
-        // resourceUrls
-        Collections.emptyMap(),
-        // vmOptions
-        Collections.emptyMap(),
-        // autoInstallComponentNames
-        Collections.emptyList(),
-        // replInitialCommands
-        Collections.emptyMap(),
-        // courseVersion
-        BuildInfo.INSTANCE.courseVersion,
-        project,
-        commonLibraryProvider,
-        Collections.emptyMap());
+    IntelliJCourse course = new ModelExtensions.TestIntelliJCourse("cool id", "testProject",
+        modules, project, commonLibraryProvider);
 
     Collection<Component> components1 = course.getComponents();
     Assertions.assertEquals(1, components1.size());
@@ -136,28 +89,8 @@ class IntelliJCourseTest {
     List<Module> modules = new ArrayList<>();
     modules.add(module);
 
-    IntelliJCourse course = new IntelliJCourse("courseId",
-        "testtesttest",
-        "http://localhost:2000",
-        Collections.emptyList(),
-        modules,
-        // libraries
-        Collections.emptyList(),
-        // exerciseModules
-        Collections.emptyMap(),
-        // resourceUrls
-        Collections.emptyMap(),
-        // vmOptions
-        Collections.emptyMap(),
-        // autoInstallComponentNames
-        Collections.emptyList(),
-        // replInitialCommands
-        Collections.emptyMap(),
-        // courseVersion
-        BuildInfo.INSTANCE.courseVersion,
-        project,
-        mock(CommonLibraryProvider.class),
-        Collections.emptyMap());
+    IntelliJCourse course = new ModelExtensions.TestIntelliJCourse("courseId", "testtesttest",
+        modules, project, mock(CommonLibraryProvider.class));
 
     Assertions.assertSame(module, course.getComponentIfExists(file));
   }
@@ -176,28 +109,9 @@ class IntelliJCourseTest {
     when(file2.getName()).thenReturn(moduleName);
     when(file2.getPath()).thenReturn("someOtherPath");
 
-    IntelliJCourse course = new IntelliJCourse("testId",
-        "testProject",
-        "http://localhost:2200",
-        Collections.emptyList(),
+    IntelliJCourse course = new ModelExtensions.TestIntelliJCourse("testId", "testProject",
         Stream.of(new ModelExtensions.TestModule(moduleName)).collect(Collectors.toList()),
-        // libraries
-        Collections.emptyList(),
-        // exerciseModules
-        Collections.emptyMap(),
-        // resourceUrls
-        Collections.emptyMap(),
-        // vmOptions
-        Collections.emptyMap(),
-        // autoInstallComponentNames
-        Collections.emptyList(),
-        // replInitialCommands
-        Collections.emptyMap(),
-        // courseVersion
-        BuildInfo.INSTANCE.courseVersion,
-        project,
-        mock(CommonLibraryProvider.class),
-        Collections.emptyMap());
+        project, mock(CommonLibraryProvider.class));
 
     Assertions.assertNull(course.getComponentIfExists(file1));
     Assertions.assertNull(course.getComponentIfExists(file2));

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -148,30 +148,8 @@ class CourseTest {
   }
 
   @Test
-  void testGetModuleWithMissingModule() throws NoSuchComponentException {
-    Course course = new ModelExtensions.TestCourse(
-        "Just some ID",
-        "Just some course",
-        "http://localhost:1951",
-        Collections.emptyList(),
-        // modules
-        Collections.emptyList(),
-        // libraries
-        Collections.emptyList(),
-        // exerciseModules
-        Collections.emptyMap(),
-        // resourceUrls
-        Collections.emptyMap(),
-        // vmOptions
-        Collections.emptyMap(),
-        // autoInstallComponentNames
-        Collections.emptyList(),
-        // replInitialCommands
-        Collections.emptyMap(),
-        // courseVersion
-        BuildInfo.INSTANCE.courseVersion,
-        // tutorials
-        Collections.emptyMap());
+  void testGetModuleWithMissingModule() {
+    Course course = new ModelExtensions.TestCourse("Some ID");
     assertThrows(NoSuchComponentException.class, () ->
         course.getComponent("Test Module"));
   }
@@ -229,8 +207,7 @@ class CourseTest {
   }
 
   @Test
-  void testFromConfigurationFileMissingId()
-      throws MalformedCourseConfigurationException {
+  void testFromConfigurationFileMissingId() {
     StringReader stringReader = new StringReader(
         "{" + nameJson + "," + urlJson + "," + languagesJson + "," + modulesJson + "}");
     assertThrows(MalformedCourseConfigurationException.class, () ->
@@ -238,8 +215,7 @@ class CourseTest {
   }
 
   @Test
-  void testFromConfigurationFileMissingName()
-      throws MalformedCourseConfigurationException {
+  void testFromConfigurationFileMissingName() {
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + urlJson + "," + languagesJson + "," + modulesJson + "}");
     assertThrows(MalformedCourseConfigurationException.class, () ->
@@ -247,8 +223,7 @@ class CourseTest {
   }
 
   @Test
-  void testFromConfigurationFileMissingUrl()
-      throws MalformedCourseConfigurationException {
+  void testFromConfigurationFileMissingUrl() {
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + nameJson + "," + languagesJson + "," + modulesJson + "}");
     assertThrows(MalformedCourseConfigurationException.class, () ->
@@ -256,8 +231,7 @@ class CourseTest {
   }
 
   @Test
-  void testFromConfigurationFileMissingLanguages()
-      throws MalformedCourseConfigurationException {
+  void testFromConfigurationFileMissingLanguages() {
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + nameJson + "," + urlJson + "," + modulesJson + "}");
     assertThrows(MalformedCourseConfigurationException.class, () ->
@@ -265,8 +239,7 @@ class CourseTest {
   }
 
   @Test
-  void testFromConfigurationFileMissingModules()
-      throws MalformedCourseConfigurationException {
+  void testFromConfigurationFileMissingModules() {
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + nameJson + "," + languagesJson + "," + urlJson + "}");
     assertThrows(MalformedCourseConfigurationException.class, () ->
@@ -274,16 +247,14 @@ class CourseTest {
   }
 
   @Test
-  void testFromConfigurationFileWithoutJson()
-      throws MalformedCourseConfigurationException {
+  void testFromConfigurationFileWithoutJson() {
     StringReader stringReader = new StringReader("random text");
     assertThrows(MalformedCourseConfigurationException.class, () ->
         Course.fromConfigurationData(stringReader, MODEL_FACTORY));
   }
 
   @Test
-  void testFromConfigurationFileWithInvalidModules()
-      throws MalformedCourseConfigurationException {
+  void testFromConfigurationFileWithInvalidModules() {
     String modules = "\"modules\":[1,2,3,4]";
     StringReader stringReader = new StringReader(
         "{" + idJson + "," + nameJson + "," + urlJson + "," + languagesJson + "," + modules + "}");
@@ -292,8 +263,7 @@ class CourseTest {
   }
 
   @Test
-  void testFromConfigurationFileWithInvalidAutoInstalls()
-      throws MalformedCourseConfigurationException {
+  void testFromConfigurationFileWithInvalidAutoInstalls() {
     String autoInstalls = "\"autoInstall\":[1,2,3,4]";
     StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson
         + "," + languagesJson + "," + modulesJson + "," + autoInstalls + "}");
@@ -302,8 +272,7 @@ class CourseTest {
   }
 
   @Test
-  void testFromConfigurationWithMalformedReplInitialCommands()
-      throws MalformedCourseConfigurationException {
+  void testFromConfigurationWithMalformedReplInitialCommands() {
     String replJson = "\"repl\": {\"initialCommands\": []}";
     StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson
         + "," + languagesJson + "," + replJson + "}");

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -1,5 +1,8 @@
 package fi.aalto.cs.apluscourses.model;
 
+import fi.aalto.cs.apluscourses.intellij.model.APlusProject;
+import fi.aalto.cs.apluscourses.intellij.model.CommonLibraryProvider;
+import fi.aalto.cs.apluscourses.intellij.model.IntelliJCourse;
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
 import fi.aalto.cs.apluscourses.utils.Version;
@@ -184,6 +187,51 @@ public class ModelExtensions {
     @Override
     public ExerciseDataSource getExerciseDataSource() {
       return exerciseDataSource;
+    }
+  }
+
+  public static class TestIntelliJCourse extends IntelliJCourse {
+
+    public TestIntelliJCourse(@NotNull String id,
+                              @NotNull String name,
+                              @NotNull APlusProject project,
+                              @NotNull CommonLibraryProvider commonLibraryProvider) {
+      this(id, name, Collections.emptyList(), project, commonLibraryProvider);
+    }
+
+    /**
+     * Constructor for testing purposes that assumes reasonable defaults for most arguments.
+     */
+    public TestIntelliJCourse(@NotNull String id,
+                              @NotNull String name,
+                              @NotNull List<Module> modules,
+                              @NotNull APlusProject project,
+                              @NotNull CommonLibraryProvider commonLibraryProvider) {
+      super(
+          id,
+          name,
+          "",
+          // languages
+          Collections.emptyList(),
+          modules,
+          // libraries
+          Collections.emptyList(),
+          // exerciseModules
+          Collections.emptyMap(),
+          // resourceUrls
+          Collections.emptyMap(),
+          // vmOptions
+          Collections.emptyMap(),
+          // autoInstallComponentNames
+          Collections.emptyList(),
+          // replInitialCommands
+          Collections.emptyMap(),
+          // courseVersion
+          BuildInfo.INSTANCE.courseVersion,
+          project,
+          commonLibraryProvider,
+          // tutorials
+          Collections.emptyMap());
     }
   }
 


### PR DESCRIPTION
# Description of the PR
Simplified Course constructors in unit tests. This should make it easier to change the Course constructor without having to touch 40 other places

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [x] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [x] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [x] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/aplus-courses/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
