### PR TITLE
Remove writing to final field

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/MyEditorNotificationPanel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/MyEditorNotificationPanel.java
@@ -4,7 +4,14 @@ import com.intellij.ui.EditorNotificationPanel;
 import java.awt.Color;
 
 public class MyEditorNotificationPanel extends EditorNotificationPanel {
+  private Color backgroundColor;
+
   public void setColor(Color color) {
-    this.myBackgroundColor = color;
+    this.backgroundColor = color;
+  }
+
+  @Override
+  public Color getBackground() {
+    return backgroundColor == null ? super.getBackground() : backgroundColor;
   }
 }


### PR DESCRIPTION
# Description of the PR
Closes #841 by overriding a method instead of setting a field that has become final in IntelliJ IDEA 2022
@OlliKiljunen should the `backgroundColor` field be volatile? After all, there are no guarantees regarding which threads are these two methods inside `MyEditorNotificationPanel` restricted to.

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/aplus-courses/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
