### PR TITLE
Use IntelliJ 2022 as default

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ dependencies {
 
 intellij {
     // this is the version of the IntelliJ IDEA API (SDK) used to build the plugin
-    version = '213.5744.223'
+    version = '221.5080.210'
     updateSinceUntilBuild = false
-    plugins = ['java', 'org.intellij.scala:2021.3.14']
+    plugins = ['java', 'org.intellij.scala:2022.1.13']
 }
 
 patchPluginXml {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
             url="https://research.cs.aalto.fi/LeTech/">LeTech Group at Aalto University
     </vendor>
     <!--  this is the range of supported IntelliJ IDEA version the plugin can be used with  -->
-    <idea-version since-build="213.*"/>
+    <idea-version since-build="213.5744.223"/>
 
     <description><![CDATA[
     This plugin supports the educational use of IntelliJ IDEA (and its Scala plugin) in programming


### PR DESCRIPTION
# Description of the PR
Updated build.gradle so that IntelliJ 2022 is used when runIde is invoked.
Also made a small change to the since-build because it seems that 213.* doesn't really allow 2021.3 for some reason (we're probably going to change that to 2022.1 before releasing 3.7 anyway)

# Testing
<table>
  <tr>
    <th>unit</th>
    <th>integration</th>
    <th>manual</th>
  </tr>
  <tr>
    <td>
      <ul>
        <li>- [ ] new <b>unit</b> tests created</li>
        <li>- [X] all <b>unit</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [ ] new <b>integration</b> tests created</li>
        <li>- [X] all <b>integration</b> tests pass</li>
      </ul>
    </td>
    <td>
      <ul>
        <li>- [X] <b>manual</b> testing went well</li>
      </ul>
    </td>
  </tr>
</table>  
  
# Have you updated the [TESTING.md](https://github.com/Aalto-LeTech/aplus-courses/blob/master/TESTING.md) or other relevant documentation on _your_ branch?

- [ ] Yes.
- [ ] Not yet. I will do it next.
- [x] Not relevant.
