### PR TITLE
REPL custom arguments

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -60,6 +60,7 @@ public class IntelliJCourse extends Course {
                         @NotNull Set<String> optionalCategories,
                         @NotNull List<String> autoInstallComponentNames,
                         @NotNull Map<String, String[]> replInitialCommands,
+                        @NotNull String replAdditionalArguments,
                         @NotNull Version courseVersion,
                         @NotNull APlusProject project,
                         @NotNull CommonLibraryProvider commonLibraryProvider,
@@ -77,6 +78,7 @@ public class IntelliJCourse extends Course {
         optionalCategories,
         autoInstallComponentNames,
         replInitialCommands,
+        replAdditionalArguments,
         courseVersion,
         tutorials);
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -49,13 +49,14 @@ public class IntelliJModelFactory implements ModelFactory {
                              @NotNull Set<String> optionalCategories,
                              @NotNull List<String> autoInstallComponentNames,
                              @NotNull Map<String, String[]> replInitialCommands,
+                             @NotNull String replAdditionalArguments,
                              @NotNull Version courseVersion,
                              @NotNull Map<Long, Tutorial> tutorials) {
 
     IntelliJCourse course =
         new IntelliJCourse(id, name, aplusUrl, languages, modules, libraries, exerciseModules,
             resourceUrls, vmOptions, optionalCategories, autoInstallComponentNames, replInitialCommands,
-            courseVersion, project, new CommonLibraryProvider(project), tutorials);
+            replAdditionalArguments, courseVersion, project, new CommonLibraryProvider(project), tutorials);
 
     Component.InitializationCallback componentInitializationCallback =
         component -> registerComponentToCourse(component, course);

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -596,7 +596,7 @@ public abstract class Course implements ComponentSource {
                                                          @NotNull String source)
       throws MalformedCourseConfigurationException {
     try {
-      return jsonObject.getString("replArguments");
+      return jsonObject.optString("replArguments", "");
     } catch (JSONException ex) {
       throw new MalformedCourseConfigurationException(source,
               "Malformed or non-string \"replArguments\" key", ex);

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -75,6 +75,9 @@ public abstract class Course implements ComponentSource {
   private final Map<String, String[]> replInitialCommands;
 
   @NotNull
+  private final String replAdditionalArguments;
+
+  @NotNull
   private final Version courseVersion;
 
   @NotNull
@@ -102,6 +105,7 @@ public abstract class Course implements ComponentSource {
                    @NotNull Set<String> optionalCategories,
                    @NotNull List<String> autoInstallComponentNames,
                    @NotNull Map<String, String[]> replInitialCommands,
+                   @NotNull String replAdditionalArguments,
                    @NotNull Version courseVersion,
                    @NotNull Map<Long, Tutorial> tutorials) {
     this.id = id;
@@ -119,6 +123,7 @@ public abstract class Course implements ComponentSource {
     this.components = Stream.concat(modules.stream(), libraries.stream())
         .collect(Collectors.toMap(Component::getName, Function.identity()));
     this.replInitialCommands = replInitialCommands;
+    this.replAdditionalArguments = replAdditionalArguments;
     this.courseVersion = courseVersion;
   }
 
@@ -173,6 +178,7 @@ public abstract class Course implements ComponentSource {
         = getCourseAutoInstallComponentNames(jsonObject, sourcePath);
     Map<String, String[]> replInitialCommands
         = getCourseReplInitialCommands(jsonObject, sourcePath);
+    String replAdditionalArguments = getCourseReplAdditionalArguments(jsonObject, sourcePath);
     Version courseVersion = getCourseVersion(jsonObject, sourcePath);
     Map<Long, Tutorial> tutorials = getTutorials(jsonObject);
     return factory.createCourse(
@@ -188,6 +194,7 @@ public abstract class Course implements ComponentSource {
         optionalCategories,
         autoInstallComponentNames,
         replInitialCommands,
+        replAdditionalArguments,
         courseVersion,
         tutorials
     );
@@ -585,6 +592,18 @@ public abstract class Course implements ComponentSource {
   }
 
   @NotNull
+  private static String getCourseReplAdditionalArguments(@NotNull JSONObject jsonObject,
+                                                         @NotNull String source)
+      throws MalformedCourseConfigurationException {
+    try {
+      return jsonObject.getString("replArguments");
+    } catch (JSONException ex) {
+      throw new MalformedCourseConfigurationException(source,
+              "Malformed or non-string \"replArguments\" key", ex);
+    }
+  }
+
+  @NotNull
   private static Version getCourseVersion(@NotNull JSONObject jsonObject,
                                           @NotNull String source)
       throws MalformedCourseConfigurationException {
@@ -669,6 +688,11 @@ public abstract class Course implements ComponentSource {
   @NotNull
   public Map<String, String[]> getReplInitialCommands() {
     return replInitialCommands;
+  }
+
+  @NotNull
+  public String getReplAdditionalArguments() {
+    return replAdditionalArguments;
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
@@ -21,6 +21,7 @@ public interface ModelFactory {
                       @NotNull Set<String> optionalCategories,
                       @NotNull List<String> autoInstallComponentNames,
                       @NotNull Map<String, String[]> replInitialCommands,
+                      @NotNull String replAdditionalArguments,
                       @NotNull Version courseVersion,
                       @NotNull Map<Long, Tutorial> tutorials);
 

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -23,6 +23,7 @@ import org.jetbrains.plugins.scala.console.actions.RunConsoleAction
 import org.jetbrains.plugins.scala.console.configuration.ScalaConsoleRunConfiguration
 import org.jetbrains.plugins.scala.project.ProjectExt
 
+import scala.collection.mutable
 import scala.jdk.CollectionConverters.ListHasAsScala
 
 /**
@@ -143,10 +144,14 @@ class ReplAction extends RunConsoleAction {
     configuration.setModule(module)
     configuration.setName(getAndReplaceText("ui.repl.console.name", module.getName))
 
+    val argsBuilder = new mutable.StringBuilder("-usejavacp " + getReplAdditionalArguments(module.getProject))
+
     ModuleUtils.createInitialReplCommandsFile(module)
     if (ModuleUtils.initialReplCommandsFileExists(module)) {
-      configuration.setMyConsoleArgs("-usejavacp -i " + MODULE_REPL_INITIAL_COMMANDS_FILE_NAME)
+      argsBuilder.append(" -i " + MODULE_REPL_INITIAL_COMMANDS_FILE_NAME)
     }
+
+    configuration.setMyConsoleArgs(argsBuilder.toString())
   }
 
   /**

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -129,6 +129,13 @@ class ReplAction extends RunConsoleAction {
     }
   }
 
+  def getReplAdditionalArguments(@NotNull project: Project): String = {
+    Option(PluginSettings.getInstance().getMainViewModel(project).courseViewModel.get) match {
+      case Some(courseViewModel) => courseViewModel.getModel.getReplAdditionalArguments
+      case None => ""
+    }
+  }
+
   def setConfigurationFields(@NotNull configuration: ScalaConsoleRunConfiguration,
                              @NotNull workingDirectory: String,
                              @NotNull module: Module): Unit = {

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -23,7 +23,7 @@ import org.jetbrains.plugins.scala.console.actions.RunConsoleAction
 import org.jetbrains.plugins.scala.console.configuration.ScalaConsoleRunConfiguration
 import org.jetbrains.plugins.scala.project.ProjectExt
 
-import scala.collection.mutable
+import scala.collection.mutable.StringBuilder
 import scala.jdk.CollectionConverters.ListHasAsScala
 
 /**
@@ -144,7 +144,7 @@ class ReplAction extends RunConsoleAction {
     configuration.setModule(module)
     configuration.setName(getAndReplaceText("ui.repl.console.name", module.getName))
 
-    val argsBuilder = new mutable.StringBuilder("-usejavacp " + getReplAdditionalArguments(module.getProject))
+    val argsBuilder = new StringBuilder("-usejavacp " + getReplAdditionalArguments(module.getProject))
 
     ModuleUtils.createInitialReplCommandsFile(module)
     if (ModuleUtils.initialReplCommandsFileExists(module)) {

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
@@ -71,6 +71,8 @@ class InstallModuleActionTest {
         Collections.emptyList(),
         // replInitialCommands
         Collections.emptyMap(),
+        // replAdditionalArguments
+        "",
         // courseVersion
         BuildInfo.INSTANCE.courseVersion,
         // tutorials

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -34,6 +34,7 @@ class CourseTest {
     Set<String> optionalCategories = Set.of("optional-category");
     List<String> autoInstallComponents = List.of(module1name);
     Map<String, String[]> replInitialCommands = new HashMap<>();
+    String replAdditionalArguments = "-test";
     replInitialCommands.put("Module1", new String[] {"import o1._"});
     Course course = new ModelExtensions.TestCourse(
         "13",
@@ -50,6 +51,7 @@ class CourseTest {
         optionalCategories,
         autoInstallComponents,
         replInitialCommands,
+        replAdditionalArguments,
         BuildInfo.INSTANCE.courseVersion,
         Collections.emptyMap());
     Assertions.assertEquals("13", course.getId(),
@@ -79,6 +81,8 @@ class CourseTest {
         "The auto-install components should be the same as those given to the constructor");
     Assertions.assertEquals("import o1._", course.getReplInitialCommands().get("Module1")[0],
         "The REPL initial commands for Module1 are correct.");
+    Assertions.assertEquals("-test", course.getReplAdditionalArguments(),
+            "The REPL arguments should be the same as that given to the constructor");
   }
 
   @Test
@@ -108,6 +112,8 @@ class CourseTest {
         Collections.emptyList(),
         // replInitialCommands
         Collections.emptyMap(),
+        // replAdditionalArguments
+        "",
         // courseVersion
         BuildInfo.INSTANCE.courseVersion,
         // tutorials
@@ -146,6 +152,8 @@ class CourseTest {
         List.of("test-module", "test-library"),
         // replInitialCommands
         Collections.emptyMap(),
+        // replAdditionalArguments
+        "",
         // courseVersion
         BuildInfo.INSTANCE.courseVersion,
         // tutorials
@@ -176,13 +184,15 @@ class CourseTest {
   private static final String autoInstallJson = "\"autoInstall\":[\"O1Library\"]";
   private static final String replInitialCommands = "\"repl\": {\"initialCommands\": {\"GoodStuff\": ["
       + "\"import o1._\",\"import o1.goodstuff._\"]}}";
+  private static final String replAdditionalArgumentsJson = "\"replArguments\": \"-test\"";
   private static final String courseVersion = "\"version\": \"5.8\"";
 
   @Test
   void testFromConfigurationFile() throws MalformedCourseConfigurationException {
     StringReader stringReader = new StringReader("{" + idJson + "," + nameJson + "," + urlJson
         + "," + languagesJson + "," + modulesJson + "," + exerciseModulesJson + "," + resourcesJson
-        + "," + vmOptionsJson + "," + autoInstallJson + "," + replInitialCommands + "," + courseVersion + "}");
+        + "," + vmOptionsJson + "," + autoInstallJson + "," + replInitialCommands
+        + "," + replAdditionalArgumentsJson + "," + courseVersion + "}");
     Course course = Course.fromConfigurationData(stringReader, "./path/to/file", MODEL_FACTORY);
     Assertions.assertEquals("1238", course.getId(), "Course should have the same ID as that in the configuration JSON");
     Assertions.assertEquals("Awesome Course", course.getName(),
@@ -211,8 +221,10 @@ class CourseTest {
         "The course should have the REPL initial commands of the configuration JSON");
     Assertions.assertEquals("import o1.goodstuff._", course.getReplInitialCommands().get("GoodStuff")[1],
         "The course should have the REPL initial commands of the configuration JSON");
+    Assertions.assertEquals("-test", course.getReplAdditionalArguments(),
+        "The course should have the REPL arguments of the configuration JSON");
     Assertions.assertEquals("5.8", course.getVersion().toString(),
-        "Course should have the same version as that in the configuration JSON");
+        "The course should have the same version as that in the configuration JSON");
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -140,10 +140,12 @@ public class ModelExtensions {
                       @NotNull Set<String> optionalCategories,
                       @NotNull List<String> autoInstallComponentNames,
                       @NotNull Map<String, String[]> replInitialCommands,
+                      @NotNull String replAdditionalArguments,
                       @NotNull Version courseVersion,
                       @NotNull Map<Long, Tutorial> tutorials) {
       super(id, name, aplusUrl, languages, modules, libraries, exerciseModules, resourceUrls, vmOptions,
-          optionalCategories, autoInstallComponentNames, replInitialCommands, courseVersion, tutorials);
+          optionalCategories, autoInstallComponentNames, replInitialCommands,
+          replAdditionalArguments, courseVersion, tutorials);
       exerciseDataSource = new TestExerciseDataSource();
     }
 
@@ -181,6 +183,8 @@ public class ModelExtensions {
           Collections.emptyList(),
           // replInitialCommands
           Collections.emptyMap(),
+          // replAdditionalArguments
+          "",
           // courseVersion
           BuildInfo.INSTANCE.courseVersion,
           // tutorials
@@ -233,6 +237,8 @@ public class ModelExtensions {
           Collections.emptyList(),
           // replInitialCommands
           Collections.emptyMap(),
+          // replAdditionalArguments
+          "",
           // courseVersion
           BuildInfo.INSTANCE.courseVersion,
           project,
@@ -414,6 +420,7 @@ public class ModelExtensions {
                                @NotNull Set<String> optionalCategories,
                                @NotNull List<String> autoInstallComponentNames,
                                @NotNull Map<String, String[]> replInitialCommands,
+                               @NotNull String replAdditionalArguments,
                                @NotNull Version courseVersion,
                                @NotNull Map<Long, Tutorial> tutorials) {
       return new ModelExtensions.TestCourse(
@@ -429,6 +436,7 @@ public class ModelExtensions {
           optionalCategories,
           autoInstallComponentNames,
           replInitialCommands,
+          replAdditionalArguments,
           courseVersion,
           tutorials
       );

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
@@ -40,6 +40,8 @@ class CourseProjectViewModelTest {
       Collections.emptyList(),
       // replInitialCommands
       Collections.emptyMap(),
+      // replAdditionalArguments
+      "",
       // courseVersion
       BuildInfo.INSTANCE.courseVersion,
       // tutorials


### PR DESCRIPTION
# Description of the PR
In the course configuration JSON, there is now an optional string called "replArguments". These are additional arguments that are going to be automatically passed to the REPL process.
For example: `"replArguments": "-new-syntax"` means that `-new-syntax` will be passed to Scala REPL process.