### PR TITLE
Action for opening module documentation

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenDocumentationAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenDocumentationAction.java
@@ -1,0 +1,74 @@
+package fi.aalto.cs.apluscourses.intellij.actions;
+
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.project.DumbAwareAction;
+import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
+import fi.aalto.cs.apluscourses.intellij.notifications.Notifier;
+import fi.aalto.cs.apluscourses.intellij.notifications.UrlRenderingErrorNotification;
+import fi.aalto.cs.apluscourses.intellij.services.CourseProjectProvider;
+import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
+import fi.aalto.cs.apluscourses.model.Component;
+import fi.aalto.cs.apluscourses.model.Course;
+import fi.aalto.cs.apluscourses.model.UrlRenderer;
+import fi.aalto.cs.apluscourses.presentation.CourseViewModel;
+import fi.aalto.cs.apluscourses.presentation.base.BaseViewModel;
+import fi.aalto.cs.apluscourses.utils.StateMonitor;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+
+public class OpenDocumentationAction extends DumbAwareAction {
+
+  @NotNull
+  private final MainViewModelProvider mainViewModelProvider;
+
+  @NotNull
+  private final UrlRenderer urlRenderer;
+
+  @NotNull
+  private final Notifier notifier;
+
+  public OpenDocumentationAction(@NotNull MainViewModelProvider mainViewModelProvider,
+                                 @NotNull UrlRenderer urlRenderer,
+                                 @NotNull Notifier notifier) {
+    this.mainViewModelProvider = mainViewModelProvider;
+    this.urlRenderer = urlRenderer;
+    this.notifier = notifier;
+  }
+
+  public OpenDocumentationAction() {
+    this(PluginSettings.getInstance(), new UrlRenderer(), new DefaultNotifier());
+  }
+
+  @Override
+  public void update(@NotNull AnActionEvent e) {
+    CourseViewModel courseViewModel =
+        mainViewModelProvider.getMainViewModel(e.getProject()).courseViewModel.get();
+    boolean isOneModuleSelected = courseViewModel != null
+        && courseViewModel.getModules().getSelectionModel().getSelectedIndices().length == 1;
+
+    if (isOneModuleSelected) {
+      Component module = courseViewModel.getModules().getSelectedElements().get(0).getModel();
+      isOneModuleSelected = module.stateMonitor.get() == Component.LOADED
+          && module.getDocumentationIndexFullPath().toFile().exists();
+    }
+
+    e.getPresentation().setEnabled(isOneModuleSelected);
+  }
+
+  @Override
+  public void actionPerformed(@NotNull AnActionEvent e) {
+    CourseViewModel courseViewModel =
+        mainViewModelProvider.getMainViewModel(e.getProject()).courseViewModel.get();
+    if (courseViewModel != null) {
+      Component module = courseViewModel.getModules().getSelectedElements().get(0).getModel();
+      try {
+        urlRenderer.show(module.getDocumentationIndexFullPath().toUri());
+      } catch (Exception ex) {
+        notifier.notify(new UrlRenderingErrorNotification(ex), e.getProject());
+      }
+    }
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Component.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Component.java
@@ -4,8 +4,10 @@ import fi.aalto.cs.apluscourses.utils.Event;
 import fi.aalto.cs.apluscourses.utils.StateMonitor;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public abstract class Component {
   public static final int NOT_INSTALLED = StateMonitor.INITIAL;
@@ -105,6 +107,11 @@ public abstract class Component {
 
   @NotNull
   public abstract Path getFullPath();
+
+  @NotNull
+  public Path getDocumentationIndexFullPath() {
+    return Paths.get(getFullPath().toString(), "doc/index.html");
+  }
 
   protected abstract int resolveStateInternal();
 

--- a/src/main/java/fi/aalto/cs/apluscourses/model/UrlRenderer.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/UrlRenderer.java
@@ -8,7 +8,11 @@ import org.jetbrains.annotations.NotNull;
 public class UrlRenderer {
 
   public void show(@NotNull String url) throws URISyntaxException {
-    BrowserUtil.browse(new URI(url));
+    this.show(new URI(url));
+  }
+
+  public void show(@NotNull URI uri) {
+    BrowserUtil.browse(uri);
   }
 
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -98,6 +98,10 @@
                     class="fi.aalto.cs.apluscourses.intellij.actions.RefreshModulesAction"
                     text="Refresh Modules"
                     icon="PluginIcons.A_PLUS_REFRESH"/>
+            <action id="fi.aalto.cs.apluscourses.intellij.actions.OpenDocumentationAction"
+                    class="fi.aalto.cs.apluscourses.intellij.actions.OpenDocumentationAction"
+                    text="Open Documentation"
+                    icon="PluginIcons.A_PLUS_REFRESH"/>
         </group>
         <group id="fi.aalto.cs.apluscourses.intellij.actions.ActionGroups.EXERCISE_ACTIONS"
                text="A+ Assignment"


### PR DESCRIPTION
# Description of the PR
After selecting a module, an option appears to open the documentation (if exists) in the default web browser
![obraz](https://user-images.githubusercontent.com/73069541/172589263-cf89c5f0-3491-4a9d-b508-98d1b49741fa.png)
