### PR TITLE
Detect submissions to the same exercise with a different group

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -124,7 +124,8 @@ public class SubmitExerciseAction extends AnAction {
         project -> PluginSettings.getInstance().getCourseFileManager(project).getLanguage(),
         PluginSettings.getInstance(),
         ProjectUtil::guessModuleDir,
-        Interfaces.DuplicateSubmissionCheckerImpl::checkForDuplicateSubmission
+        Interfaces.DuplicateSubmissionCheckerImpl::checkForDuplicateSubmission,
+        new Interfaces.SubmissionGroupSelectorImpl()
     );
   }
 
@@ -143,7 +144,8 @@ public class SubmitExerciseAction extends AnAction {
                               @NotNull Interfaces.LanguageSource languageSource,
                               @NotNull DefaultGroupIdSetting defaultGroupIdSetting,
                               @NotNull Interfaces.ModuleDirGuesser moduleDirGuesser,
-                              @NotNull Interfaces.DuplicateSubmissionChecker duplicateChecker) {
+                              @NotNull Interfaces.DuplicateSubmissionChecker duplicateChecker,
+                              @NotNull Interfaces.SubmissionGroupSelector groupSelector) {
     this.mainViewModelProvider = mainViewModelProvider;
     this.authenticationProvider = authenticationProvider;
     this.fileFinder = fileFinder;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import org.apache.commons.io.FileUtils;
 import org.jetbrains.annotations.NotNull;
@@ -310,7 +311,8 @@ public class SubmitExerciseAction extends AnAction {
 
     Group lastSubmittedGroup = groups
         .stream()
-        .filter(g -> groupSelector.isGroupAllowedForExercise(course.getId(), exercise.getId(), g))
+        .filter(g -> g.getMemberwiseId().equals(
+            groupSelector.getLastSubmittedGroupId(project, course.getId(), exercise.getId())))
         .findFirst()
         .orElse(null);
 
@@ -334,6 +336,9 @@ public class SubmitExerciseAction extends AnAction {
     logger.info("Submitting with group: {}", submission.selectedGroup.get());
     String submissionUrl = exerciseDataSource.submit(submission.buildSubmission(), authentication);
     logger.info("Submission url: {}", submissionUrl);
+
+    groupSelector.onAssignmentSubmitted(project, course.getId(), exercise.getId(),
+        Objects.requireNonNull(submission.selectedGroup.get()));
 
     new SubmissionStatusUpdater(
         project, exerciseDataSource, authentication, submissionUrl, selectedExercise.getModel(), course

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -290,8 +290,7 @@ public class SubmitExerciseAction extends AnAction {
     var exerciseDataSource = course.getExerciseDataSource();
 
     List<Group> groups = new ArrayList<>(exerciseDataSource.getGroups(course, authentication));
-    groups.add(0, new Group(-1, Collections
-        .singletonList(getText("ui.toolWindow.subTab.exercises.submission.submitAlone"))));
+    groups.add(0, Group.GROUP_ALONE);
 
     // Find the group from the available groups that matches the default group ID.
     // A group could be removed, so this way we check that the default group ID is still valid.
@@ -383,11 +382,9 @@ public class SubmitExerciseAction extends AnAction {
     Map<String, Path> files = Map.of(submittableFiles.get(0).getKey(), tutorialResultFile.toPath());
 
     // IDE activities are always submitted alone
-    var aloneGroup =
-        new Group(-1, Collections.singletonList(getText("ui.toolWindow.subTab.exercises.submission.submitAlone")));
-    List<Group> groups = List.of(aloneGroup);
+    List<Group> groups = List.of(Group.GROUP_ALONE);
 
-    SubmissionViewModel submission = new SubmissionViewModel(exercise, groups, aloneGroup, files, language);
+    SubmissionViewModel submission = new SubmissionViewModel(exercise, groups, Group.GROUP_ALONE, files, language);
 
     final var exerciseDataSource = courseViewModel.getModel().getExerciseDataSource();
     String submissionUrl = exerciseDataSource.submit(submission.buildSubmission(), authentication);

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
@@ -62,8 +62,7 @@ public class Interfaces {
   }
 
   public interface SubmissionGroupSelector {
-    boolean isGroupAllowedForExercise(@NotNull Project project, @NotNull String courseId, long exerciseId,
-                                      @NotNull Group group);
+    boolean isGroupAllowedForExercise(@NotNull String courseId, long exerciseId, @NotNull Group group);
 
     void onAssignmentSubmitted(@NotNull Project project, @NotNull String courseId, long exerciseId,
                                @NotNull Group group);
@@ -319,8 +318,7 @@ public class Interfaces {
     }
 
     @Override
-    public boolean isGroupAllowedForExercise(@NotNull Project project, @NotNull String courseId, long exerciseId,
-                                             @NotNull Group group) {
+    public boolean isGroupAllowedForExercise(@NotNull String courseId, long exerciseId, @NotNull Group group) {
       if (groupsCache == null) {
         return true;
       }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
@@ -62,9 +62,6 @@ public class Interfaces {
   }
 
   public interface SubmissionGroupSelector {
-    boolean isGroupAllowedForExercise(@NotNull Project project, @NotNull String courseId, long exerciseId,
-                                      @NotNull Group group);
-
     @Nullable
     String getLastSubmittedGroupId(@NotNull Project project, @NotNull String courseId, long exerciseId);
 
@@ -318,17 +315,11 @@ public class Interfaces {
     }
 
     @NotNull
-    private JSONObject getGroupCacheObject(@NotNull Group currentGroup) {
+    private JSONObject createCacheObjectForGroup(@NotNull Group currentGroup) {
       final JSONObject jsonObject = new JSONObject();
       jsonObject.put(JSON_ENTRY_NAME, currentGroup.getMemberwiseId());
 
       return jsonObject;
-    }
-
-    @Override
-    public boolean isGroupAllowedForExercise(@NotNull Project project, @NotNull String courseId, long exerciseId,
-                                             @NotNull Group group) {
-      return group.getMemberwiseId().equals(getLastSubmittedGroupId(project, courseId, exerciseId));
     }
 
     @Override
@@ -343,6 +334,7 @@ public class Interfaces {
         return null;
       }
 
+      // if null is returned, then there were no past submissions and any group is allowed
       return cachedGroupJson.optString(JSON_ENTRY_NAME);
     }
 
@@ -352,7 +344,7 @@ public class Interfaces {
       ensureCacheLoaded(project);
 
       final String cacheKey = getCacheKey(courseId, exerciseId);
-      groupsCache.putValue(cacheKey, getGroupCacheObject(group), CachePreferences.PERMANENT);
+      groupsCache.putValue(cacheKey, createCacheObjectForGroup(group), CachePreferences.PERMANENT);
     }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
@@ -64,6 +64,7 @@ public class Interfaces {
   public interface SubmissionGroupSelector {
     boolean isGroupAllowedForExercise(@NotNull Project project, @NotNull String courseId, long exerciseId,
                                       @NotNull Group group);
+    
     void onAssignmentSubmitted(@NotNull Project project, @NotNull String courseId, long exerciseId,
                                @NotNull Group group);
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
@@ -301,7 +301,7 @@ public class Interfaces {
     private static final String JSON_ENTRY_NAME = "lastGroup";
     private static Cache<String, JSONObject> groupsCache;
 
-    private void ensureCacheLoaded(@NotNull Project project) {
+    private static void ensureCacheLoaded(@NotNull Project project) {
       if (groupsCache == null) {
         Path projectPath = Path.of(Objects.requireNonNull(project.getBasePath()));
         groupsCache = new JsonFileCache(
@@ -310,12 +310,12 @@ public class Interfaces {
     }
 
     @NotNull
-    private String getCacheKey(@NotNull String courseId, long exerciseId) {
+    private static String getCacheKey(@NotNull String courseId, long exerciseId) {
       return "lastGroup_c" + courseId + "_e" + exerciseId;
     }
 
     @NotNull
-    private JSONObject createCacheObjectForGroup(@NotNull Group currentGroup) {
+    private static JSONObject createCacheObjectForGroup(@NotNull Group currentGroup) {
       final JSONObject jsonObject = new JSONObject();
       jsonObject.put(JSON_ENTRY_NAME, currentGroup.getMemberwiseId());
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
@@ -64,7 +64,7 @@ public class Interfaces {
   public interface SubmissionGroupSelector {
     boolean isGroupAllowedForExercise(@NotNull Project project, @NotNull String courseId, long exerciseId,
                                       @NotNull Group group);
-    
+
     void onAssignmentSubmitted(@NotNull Project project, @NotNull String courseId, long exerciseId,
                                @NotNull Group group);
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Group.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Group.java
@@ -1,6 +1,7 @@
 package fi.aalto.cs.apluscourses.model;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Group.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Group.java
@@ -1,19 +1,43 @@
 package fi.aalto.cs.apluscourses.model;
 
+import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
 public class Group {
 
+  public static class GroupMember {
+    private final long id;
+    private final @NotNull String name;
+
+    public long getId() {
+      return id;
+    }
+
+    @NotNull
+    public String getName() {
+      return name;
+    }
+
+    public GroupMember(long id, @NotNull String name) {
+      this.id = id;
+      this.name = name;
+    }
+  }
+
+  public static final @NotNull Group GROUP_ALONE = new Group(-1, Collections
+      .singletonList(new GroupMember(-1, getText("ui.toolWindow.subTab.exercises.submission.submitAlone"))));
+
   private final long id;
 
-  private final List<String> memberNames;
+  private final List<GroupMember> memberNames;
 
-  public Group(long id, @NotNull List<String> memberNames) {
+  public Group(long id, @NotNull List<GroupMember> memberNames) {
     this.id = id;
     this.memberNames = memberNames;
   }
@@ -27,9 +51,11 @@ public class Group {
   public static Group fromJsonObject(@NotNull JSONObject jsonObject) {
     long id = jsonObject.getLong("id");
     JSONArray members = jsonObject.getJSONArray("members");
-    List<String> memberNames = new ArrayList<>(members.length());
+    List<GroupMember> memberNames = new ArrayList<>(members.length());
     for (int i = 0; i < members.length(); ++i) {
-      memberNames.add(members.getJSONObject(i).getString("full_name"));
+      GroupMember member = new GroupMember(members.getJSONObject(i).getInt("id"),
+          members.getJSONObject(i).getString("full_name"));
+      memberNames.add(member);
     }
     return new Group(id, memberNames);
   }
@@ -40,9 +66,8 @@ public class Group {
 
   @NotNull
   public List<String> getMemberNames() {
-    return Collections.unmodifiableList(memberNames);
+    return memberNames.stream().map(x -> x.name).collect(Collectors.toUnmodifiableList());
   }
-
 
   @Override
   public int hashCode() {
@@ -56,6 +81,6 @@ public class Group {
 
   @Override
   public String toString() {
-    return "Group{" + memberNames + '}';
+    return "Group{" + getMemberNames() + '}';
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Group.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Group.java
@@ -35,11 +35,12 @@ public class Group {
 
   private final long id;
 
-  private final List<GroupMember> memberNames;
+  @NotNull
+  private final List<GroupMember> members;
 
-  public Group(long id, @NotNull List<GroupMember> memberNames) {
+  public Group(long id, @NotNull List<GroupMember> members) {
     this.id = id;
-    this.memberNames = memberNames;
+    this.members = members;
   }
 
   /**
@@ -66,7 +67,17 @@ public class Group {
 
   @NotNull
   public List<String> getMemberNames() {
-    return memberNames.stream().map(x -> x.name).collect(Collectors.toUnmodifiableList());
+    return members.stream().map(x -> x.name).collect(Collectors.toUnmodifiableList());
+  }
+
+  /**
+   * Returns an identifier for the group, based on the members of the group. The difference between this and
+   * {@link #getId() getId} is that this method will return the same ID for two different groups if their
+   * members are the same.
+   */
+  @NotNull
+  public String getMemberwiseId() {
+    return members.stream().map(x -> x.id).sorted().map(String::valueOf).collect(Collectors.joining(","));
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
@@ -53,6 +53,7 @@ public class SubmissionViewModel {
   public SubmissionViewModel(@NotNull Exercise exercise,
                              @NotNull List<Group> availableGroups,
                              @Nullable Group defaultGroup,
+                             @Nullable Group lastSubmittedGroup,
                              @NotNull Map<String, Path> filePaths,
                              @NotNull String language) {
     this.exercise = exercise;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
@@ -26,15 +26,23 @@ public class SubmissionViewModel {
 
   private static final Logger logger = APlusLogger.logger;
 
+  @NotNull
   private final Exercise exercise;
 
+  @NotNull
   private final List<Group> availableGroups;
 
+  @NotNull
   private final Map<String, Path> filePaths;
 
+  @NotNull
   private final SubmittableFile[] submittableFiles;
 
+  @NotNull
   private final String language;
+
+  @Nullable
+  private final Group lastSubmittedGroup;
 
   public final ObservableProperty<Group> selectedGroup =
       new ObservableReadWriteProperty<>(null, SubmissionViewModel::validateGroupSelection);
@@ -58,6 +66,7 @@ public class SubmissionViewModel {
                              @NotNull String language) {
     this.exercise = exercise;
     this.availableGroups = availableGroups;
+    this.lastSubmittedGroup = lastSubmittedGroup;
     this.filePaths = filePaths;
     this.language = language;
     this.submittableFiles = exercise
@@ -85,6 +94,10 @@ public class SubmissionViewModel {
 
   public int getCurrentSubmissionNumber() {
     return exercise.getSubmissionResults().size() + 1;
+  }
+
+  public boolean isAbleToSubmitWithGroup(@Nullable Group selectedGroup) {
+    return selectedGroup == null || lastSubmittedGroup == null || selectedGroup == lastSubmittedGroup;
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
@@ -96,7 +96,12 @@ public class SubmissionViewModel {
     return exercise.getSubmissionResults().size() + 1;
   }
 
+  /**
+   * Checks if the user is able to submit with the selected group.
+   */
   public boolean isAbleToSubmitWithGroup(@Nullable Group selectedGroup) {
+    // if the selectedGroup is null, there is no selection, so there's nothing to warn the user against
+    // if the lastSubmittedGroup is null, there have been no past submissions, so all groups are fine
     return selectedGroup == null || lastSubmittedGroup == null || selectedGroup == lastSubmittedGroup;
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.form
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.form
@@ -112,8 +112,8 @@
           <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
-          <text value="test warning"/>
-          <visible value="true"/>
+          <text value=""/>
+          <visible value="false"/>
         </properties>
       </component>
     </children>

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.form
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="fi.aalto.cs.apluscourses.ui.exercise.SubmissionDialog">
-  <grid id="27dc6" binding="basePanel" layout-manager="GridLayoutManager" row-count="12" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="basePanel" layout-manager="GridLayoutManager" row-count="13" column-count="4" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="620" height="400"/>
@@ -33,13 +33,13 @@
       </component>
       <component id="46e37" class="javax.swing.JLabel" binding="submissionCount" custom-create="true">
         <constraints>
-          <grid row="10" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <component id="acd" class="javax.swing.JLabel" binding="filenames" custom-create="true">
         <constraints>
-          <grid row="9" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="10" column="1" row-span="1" col-span="2" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -58,41 +58,41 @@
       </vspacer>
       <component id="4eb0e" class="javax.swing.JSeparator">
         <constraints>
-          <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="6" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
       <vspacer id="527aa">
         <constraints>
-          <grid row="6" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="7" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="6"/>
           </grid>
         </constraints>
       </vspacer>
       <hspacer id="a5085">
         <constraints>
-          <grid row="9" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="10" column="0" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="4" height="-1"/>
           </grid>
         </constraints>
       </hspacer>
       <hspacer id="b5056">
         <constraints>
-          <grid row="9" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
+          <grid row="10" column="3" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false">
             <preferred-size width="4" height="-1"/>
           </grid>
         </constraints>
       </hspacer>
       <vspacer id="7440b">
         <constraints>
-          <grid row="8" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
+          <grid row="9" column="1" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false">
             <preferred-size width="-1" height="6"/>
           </grid>
         </constraints>
       </vspacer>
       <component id="1d5dd" class="javax.swing.JLabel" binding="warning">
         <constraints>
-          <grid row="11" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="12" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <foreground color="-65536"/>
@@ -101,10 +101,19 @@
       </component>
       <component id="abf79" class="fi.aalto.cs.apluscourses.ui.base.CheckBox" binding="defaultGroupCheckBox">
         <constraints>
-          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties>
           <text resource-bundle="resources" key="ui.toolWindow.subTab.exercises.submission.defaultToThisGroup"/>
+        </properties>
+      </component>
+      <component id="7e89e" class="javax.swing.JLabel" binding="groupWarning">
+        <constraints>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="test warning"/>
+          <visible value="true"/>
         </properties>
       </component>
     </children>

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
@@ -10,6 +10,7 @@ import fi.aalto.cs.apluscourses.ui.GuiObject;
 import fi.aalto.cs.apluscourses.ui.base.CheckBox;
 import fi.aalto.cs.apluscourses.ui.base.OurComboBox;
 import fi.aalto.cs.apluscourses.ui.base.OurDialogWrapper;
+import java.awt.event.ItemEvent;
 import javax.swing.Action;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -35,6 +36,7 @@ public class SubmissionDialog extends OurDialogWrapper {
   @GuiObject
   private JLabel filenames;
   private JLabel warning;
+  private JLabel groupWarning;
 
   /**
    * Construct a submission dialog with the given view model.
@@ -76,6 +78,12 @@ public class SubmissionDialog extends OurDialogWrapper {
     groupComboBox =
         new OurComboBox<>(viewModel.getAvailableGroups().toArray(new Group[0]), Group.class);
     groupComboBox.setRenderer(new GroupRenderer());
+    groupComboBox.addItemListener(e -> {
+      if (e.getStateChange() == ItemEvent.SELECTED) {
+        Group selectedGroup = (Group) e.getItem();
+
+      }
+    });
 
     StringBuilder filenamesHtml = new StringBuilder("<html><body>Files:<ul>");
     for (SubmittableFile file : viewModel.getFiles()) {

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
@@ -60,8 +60,7 @@ public class SubmissionDialog extends OurDialogWrapper {
 
     warning.setText(viewModel.getSubmissionWarning(project));
 
-    groupWarning.setText("<html><body>You have previously submitted this assignment in a different group.<br>" +
-        "Changing the group might cause the submission to fail.</body></html>");
+    groupWarning.setText(getText("ui.toolWindow.subTab.exercises.submission.groupConflict"));
     groupWarning.setForeground(new JBColor(new Color(192, 96, 0), new Color(192, 192, 0)));
 
     init();
@@ -81,18 +80,16 @@ public class SubmissionDialog extends OurDialogWrapper {
 
   @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
   private void createUIComponents() {
-    exerciseName = new JLabel("<html><body><h2>" + viewModel.getPresentableExerciseName()
-        + "</h2></body></html>");
+    exerciseName = new JLabel("<html><body><h2>" + viewModel.getPresentableExerciseName() + "</h2></body></html>");
 
-    groupComboBox =
-        new OurComboBox<>(viewModel.getAvailableGroups().toArray(new Group[0]), Group.class);
+    groupComboBox = new OurComboBox<>(viewModel.getAvailableGroups().toArray(new Group[0]), Group.class);
     groupComboBox.setRenderer(new GroupRenderer());
     groupComboBox.addItemListener(e -> {
       if (e.getStateChange() == ItemEvent.SELECTED) {
         Group selectedGroup = (Group) e.getItem();
         groupWarning.setVisible(!viewModel.isAbleToSubmitWithGroup(selectedGroup));
 
-        // we need the resize operation to execute after this handler is done executing
+        // we need the resize operation to run after this handler is done executing
         // otherwise the setVisible change won't be picked up by the layout manager
         SwingUtilities.invokeLater(this::pack);
       }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/exercise/SubmissionDialog.java
@@ -2,7 +2,10 @@ package fi.aalto.cs.apluscourses.ui.exercise;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.ui.Gray;
+import com.intellij.ui.JBColor;
 import fi.aalto.cs.apluscourses.model.Group;
 import fi.aalto.cs.apluscourses.model.SubmittableFile;
 import fi.aalto.cs.apluscourses.presentation.exercise.SubmissionViewModel;
@@ -10,11 +13,13 @@ import fi.aalto.cs.apluscourses.ui.GuiObject;
 import fi.aalto.cs.apluscourses.ui.base.CheckBox;
 import fi.aalto.cs.apluscourses.ui.base.OurComboBox;
 import fi.aalto.cs.apluscourses.ui.base.OurDialogWrapper;
+import java.awt.Color;
 import java.awt.event.ItemEvent;
 import javax.swing.Action;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -55,6 +60,10 @@ public class SubmissionDialog extends OurDialogWrapper {
 
     warning.setText(viewModel.getSubmissionWarning(project));
 
+    groupWarning.setText("<html><body>You have previously submitted this assignment in a different group.<br>" +
+        "Changing the group might cause the submission to fail.</body></html>");
+    groupWarning.setForeground(new JBColor(new Color(192, 96, 0), new Color(192, 192, 0)));
+
     init();
   }
 
@@ -81,7 +90,11 @@ public class SubmissionDialog extends OurDialogWrapper {
     groupComboBox.addItemListener(e -> {
       if (e.getStateChange() == ItemEvent.SELECTED) {
         Group selectedGroup = (Group) e.getItem();
+        groupWarning.setVisible(!viewModel.isAbleToSubmitWithGroup(selectedGroup));
 
+        // we need the resize operation to execute after this handler is done executing
+        // otherwise the setVisible change won't be picked up by the layout manager
+        SwingUtilities.invokeLater(this::pack);
       }
     });
 

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -122,6 +122,7 @@ ui.moduleSelectionDialog.setManually=If the path to the module is incorrect, ple
 ui.toolWindow.subTab.exercises.name=Assignments
 ui.toolWindow.subTab.exercises.nameStudent=Assignments: {0}
 ui.toolWindow.subTab.exercises.submission.selectGroup=Select group
+ui.toolWindow.subTab.exercises.submission.groupConflict=<html>You have previously submitted this assignment in a different group.<br>Changing the group might cause the submission to fail.</html>
 ui.toolWindow.subTab.exercises.submission.submitAs=Submit as:
 ui.toolWindow.subTab.exercises.submission.submitAlone=Submit alone
 ui.toolWindow.subTab.exercises.submission.submitExercise=Submit Assignment

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.module.Module;
@@ -223,8 +224,11 @@ class SubmitExerciseActionTest {
     Interfaces.ModuleDirGuesser moduleDirGuesser = m -> moduleDir;
     Interfaces.DuplicateSubmissionChecker duplicateChecker = (p, c, e, f) -> true;
 
+    Interfaces.SubmissionGroupSelector groupSelector = mock(Interfaces.SubmissionGroupSelector.class);
+
     action = new SubmitExerciseAction(mainVmProvider, authProvider, fileFinder, moduleSource, dialogs, notifier,
-        tagger, documentSaver, languageSource, defaultGroupIdSetting, moduleDirGuesser, duplicateChecker);
+        tagger, documentSaver, languageSource, defaultGroupIdSetting, moduleDirGuesser, duplicateChecker,
+        groupSelector);
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -129,7 +129,7 @@ class SubmitExerciseActionTest {
     exercise = new Exercise(
         exerciseId, "Test exercise", "http://localhost:10000", submissionInfo, 0, 0,
         OptionalLong.empty(), null, false);
-    group = new Group(124, Collections.singletonList("Only you"));
+    group = new Group(124, Collections.singletonList(new Group.GroupMember(1, "Only you")));
     groups = Collections.singletonList(group);
     exerciseGroup = new ExerciseGroup(0, "Test EG", "", true, List.of(), List.of());
     exerciseGroup.addExercise(exercise);

--- a/src/test/java/fi/aalto/cs/apluscourses/model/GroupTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/GroupTest.java
@@ -17,7 +17,9 @@ class GroupTest {
 
   @Test
   void testGroup() {
-    Group group = new Group(123, List.of("John", "Catherine"));
+    Group group = new Group(123, List.of(
+        new Group.GroupMember(1, "John"),
+        new Group.GroupMember(2, "Catherine")));
     Assertions.assertEquals(123, group.getId(), "The ID should be equal to the one given to the constructor");
     Assertions.assertEquals("John", group.getMemberNames().get(0),
         "The member names should be equal to those given to the constructor");

--- a/src/test/java/fi/aalto/cs/apluscourses/model/GroupTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/GroupTest.java
@@ -38,8 +38,8 @@ class GroupTest {
     JSONObject json = new JSONObject()
         .put("id", 145)
         .put("members", new JSONArray()
-            .put(new JSONObject().put("full_name", "Erkki"))
-            .put(new JSONObject().put("full_name", "Henkka")));
+            .put(new JSONObject().put("full_name", "Erkki").put("id", 4))
+            .put(new JSONObject().put("full_name", "Henkka").put("id", 17)));
 
     Group group = Group.fromJsonObject(json);
 
@@ -48,6 +48,8 @@ class GroupTest {
         "The member names should be equal to those in the JSON object");
     Assertions.assertEquals("Henkka", group.getMemberNames().get(1),
         "The member names should be equal to those in the JSON object");
+    Assertions.assertEquals("4,17", group.getMemberwiseId(),
+        "The memberwise ID should be correct");
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -37,7 +37,8 @@ public class ModelExtensions {
     @NotNull
     @Override
     public List<Group> getGroups(@NotNull Course course, @NotNull Authentication authentication) {
-      return Collections.singletonList(new Group(0, Collections.singletonList("Only you")));
+      return Collections.singletonList(new Group(0,
+          Collections.singletonList(new Group.GroupMember(1, "Only you"))));
     }
 
     @NotNull

--- a/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/SubmissionTest.java
@@ -29,7 +29,7 @@ class SubmissionTest {
     Map<String, Path> files = new HashMap<>();
     files.put("fileA", Paths.get("some.file"));
     files.put("fileB", Paths.get("other.file"));
-    Group group = new Group(0, Collections.singletonList("Only me"));
+    Group group = new Group(0, Collections.singletonList(new Group.GroupMember(1, "Only me")));
 
     Submission submission = new Submission(exercise, files, group, language);
 

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
@@ -48,7 +48,7 @@ class SubmissionViewModelTest {
         100, "Exercise", "http://localhost:1000", submissionInfo, 0, 0, OptionalLong.empty(), null, false);
 
     SubmissionViewModel submissionViewModel =
-        new SubmissionViewModel(exercise, groups, null, fileMap, language);
+        new SubmissionViewModel(exercise, groups, null, null, fileMap, language);
 
     Assertions.assertNotNull(submissionViewModel.selectedGroup.validate(),
         "The validation should fail when no group is yet selected");
@@ -62,7 +62,7 @@ class SubmissionViewModelTest {
         new SubmissionResult(i, 10, 0.0, SubmissionResult.Status.GRADED, exercise)));
 
     SubmissionViewModel submissionViewModel1 = new SubmissionViewModel(
-        exercise, Collections.emptyList(), null, Collections.emptyMap(), "");
+        exercise, Collections.emptyList(), null, null, Collections.emptyMap(), "");
 
     Assertions.assertEquals(4, submissionViewModel1.getCurrentSubmissionNumber());
     Assertions.assertEquals("You are about to make submission 4 out of 5.",
@@ -73,14 +73,14 @@ class SubmissionViewModelTest {
     exercise.addSubmissionResult(
         new SubmissionResult(3, 10, 0.0, SubmissionResult.Status.GRADED, exercise));
     SubmissionViewModel submissionViewModel2 = new SubmissionViewModel(
-        exercise, Collections.emptyList(), null, Collections.emptyMap(), "");
+        exercise, Collections.emptyList(), null, null, Collections.emptyMap(), "");
 
     Assertions.assertEquals("You are about to make submission 5 out of 5.",
         submissionViewModel2.getSubmissionCountText());
     Assertions.assertNotNull(submissionViewModel2.getSubmissionWarning(project));
 
     SubmissionViewModel submissionViewModel3 = new SubmissionViewModel(
-        exercise, Collections.emptyList(), null, Collections.emptyMap(), "");
+        exercise, Collections.emptyList(), null, null, Collections.emptyMap(), "");
 
     exercise.addSubmissionResult(
         new SubmissionResult(4, 10, 0.0, SubmissionResult.Status.GRADED, exercise));
@@ -91,7 +91,7 @@ class SubmissionViewModelTest {
     // Max submissions 0
     SubmissionViewModel submissionViewModel4 = new SubmissionViewModel(
         new Exercise(0, "", "", info, 0, 0, OptionalLong.empty(), null, false),
-        Collections.emptyList(), null, Collections.emptyMap(), "");
+        Collections.emptyList(), null, null, Collections.emptyMap(), "");
     Assertions.assertEquals("You are about to make submission 1.", submissionViewModel4.getSubmissionCountText());
     Assertions.assertNull(submissionViewModel4.getSubmissionWarning(project));
   }
@@ -110,7 +110,7 @@ class SubmissionViewModelTest {
         OptionalLong.empty(), null, false);
 
     SubmissionViewModel submission = new SubmissionViewModel(
-        exercise, Collections.emptyList(), null, Collections.emptyMap(), "fi"
+        exercise, Collections.emptyList(), null, null, Collections.emptyMap(), "fi"
     );
 
     Assertions.assertArrayEquals(new SubmittableFile[] {finnishFile1, finnishFile2}, submission.getFiles(),
@@ -128,10 +128,10 @@ class SubmissionViewModelTest {
     List<Group> availableGroups = Collections.singletonList(group);
 
     SubmissionViewModel viewModel1 = new SubmissionViewModel(
-        exercise, availableGroups, null, Collections.emptyMap(), "fi"
+        exercise, availableGroups, null, null, Collections.emptyMap(), "fi"
     );
     SubmissionViewModel viewModel2 = new SubmissionViewModel(
-        exercise, availableGroups, group, Collections.emptyMap(), "fi"
+        exercise, availableGroups, group, null, Collections.emptyMap(), "fi"
     );
 
     Assertions.assertNull(viewModel1.selectedGroup.get());

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModelTest.java
@@ -30,10 +30,7 @@ class SubmissionViewModelTest {
 
   @Test
   void testValidation() {
-    List<String> names = new ArrayList<>();
-    names.add("Someone");
-
-    Group group = new Group(200, names);
+    Group group = new Group(200, Collections.singletonList(new Group.GroupMember(1, "Someone")));
     List<Group> groups = new ArrayList<>();
     groups.add(group);
 
@@ -125,7 +122,9 @@ class SubmissionViewModelTest {
     Exercise exercise = new Exercise(
         1000, "wow", "http://www.fi", new SubmissionInfo(Collections.emptyMap()), 0, 0,
         OptionalLong.empty(), null, false);
-    Group group = new Group(1, List.of("Jyrki", "Jorma"));
+    Group group = new Group(1, List.of(
+        new Group.GroupMember(1, "Jyrki"),
+        new Group.GroupMember(1, "Jorma")));
     List<Group> availableGroups = Collections.singletonList(group);
 
     SubmissionViewModel viewModel1 = new SubmissionViewModel(


### PR DESCRIPTION
# Description of the PR
Whenever a student submits an assignment, the plugin stores the information about the group which the user has selected. Then, if the user attempts to submit again with a different group, a warning message will appear in the submission dialog.

To achieve this, the Group class now contains the user IDs. The plugin can construct a "group memberwise ID" such that two groups with the same members have the same memberwise ID.

![obraz](https://user-images.githubusercontent.com/73069541/177222445-fc05407c-bbcb-4b7d-a9da-5c6a8713100d.png)
