### PR TITLE
Cache duplicate submissions only if operation is successful

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -50,13 +50,13 @@ import fi.aalto.cs.apluscourses.presentation.exercise.ExercisesTreeViewModel;
 import fi.aalto.cs.apluscourses.presentation.exercise.SubmissionResultViewModel;
 import fi.aalto.cs.apluscourses.presentation.exercise.SubmissionViewModel;
 import fi.aalto.cs.apluscourses.presentation.ideactivities.TutorialViewModel;
+import fi.aalto.cs.apluscourses.ui.DuplicateSubmissionDialog;
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +128,7 @@ public class SubmitExerciseAction extends AnAction {
         project -> PluginSettings.getInstance().getCourseFileManager(project).getLanguage(),
         PluginSettings.getInstance(),
         ProjectUtil::guessModuleDir,
-        Interfaces.DuplicateSubmissionCheckerImpl::checkForDuplicateSubmission,
+        new Interfaces.DuplicateSubmissionCheckerImpl(),
         new Interfaces.SubmissionGroupSelectorImpl()
     );
   }
@@ -324,7 +324,8 @@ public class SubmitExerciseAction extends AnAction {
       return;
     }
 
-    if (!duplicateChecker.checkForDuplicateSubmission(project, course.getId(), exercise.getId(), files)) {
+    if (duplicateChecker.isDuplicateSubmission(project, course.getId(), exercise.getId(), files)
+        && !DuplicateSubmissionDialog.showDialog()) {
       return;
     }
 
@@ -341,6 +342,7 @@ public class SubmitExerciseAction extends AnAction {
     logger.info("Submission url: {}", submissionUrl);
 
     groupSelector.onAssignmentSubmitted(project, course.getId(), exercise.getId(), selectedGroup);
+    duplicateChecker.onAssignmentSubmitted(project, course.getId(), exercise.getId(), files);
 
     new SubmissionStatusUpdater(
         project, exerciseDataSource, authentication, submissionUrl, selectedExercise.getModel(), course

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/Interfaces.java
@@ -10,7 +10,6 @@ import fi.aalto.cs.apluscourses.intellij.actions.SubmitExerciseAction;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.model.Authentication;
 import fi.aalto.cs.apluscourses.model.Group;
-import fi.aalto.cs.apluscourses.ui.DuplicateSubmissionDialog;
 import fi.aalto.cs.apluscourses.utils.cache.Cache;
 import fi.aalto.cs.apluscourses.utils.cache.CachePreferences;
 import fi.aalto.cs.apluscourses.utils.cache.JsonFileCache;
@@ -60,7 +59,7 @@ public class Interfaces {
                                   @NotNull Map<String, Path> files);
 
     void onAssignmentSubmitted(@NotNull Project project, @NotNull String courseId, long exerciseId,
-                                  @NotNull Map<String, Path> files);
+                               @NotNull Map<String, Path> files);
   }
 
   public interface SubmissionGroupSelector {

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -222,8 +222,7 @@ class SubmitExerciseActionTest {
     VirtualFile moduleDir = mock(VirtualFile.class);
     doReturn(filePath.getParent().toString()).when(moduleDir).getPath();
     Interfaces.ModuleDirGuesser moduleDirGuesser = m -> moduleDir;
-    Interfaces.DuplicateSubmissionChecker duplicateChecker = (p, c, e, f) -> true;
-
+    Interfaces.DuplicateSubmissionChecker duplicateChecker = mock(Interfaces.DuplicateSubmissionChecker.class);
     Interfaces.SubmissionGroupSelector groupSelector = mock(Interfaces.SubmissionGroupSelector.class);
 
     action = new SubmitExerciseAction(mainVmProvider, authProvider, fileFinder, moduleSource, dialogs, notifier,

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.module.Module;


### PR DESCRIPTION
# Description of the PR
Previously, a submission was hashed & added to the submitted list even if the submission failed. This meant that if someone's submission failed due to network error, subsequent attempts would show the "duplicate submission" dialog. This has been fixed here.