### PR TITLE
Removed text attributes from Scala prompt

### DIFF
--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
@@ -58,9 +58,10 @@ class Repl(module: Module) extends ScalaLanguageConsole(module: Module) {
     // In Scala 3 REPL, the "scala>" prompt is colored blue by sending appropriate ANSI sequences
     // This is not handled correctly by Scala plugin which expects the prompt to be sent with
     // the NORMAL_OUTPUT attributes; this breaks the REPL state machine
-    // Therefore we override the text attributes for the prompt. The only unintended consequence
+    // Therefore we override the text attributes for the prompt. The unintended consequence
     // of this fix is that output lines equal to the prompt will also lose their text attributes.
-    super.print(updatedText, if (text.trim == "scala>")
-      ConsoleViewContentType.NORMAL_OUTPUT else contentType)
+    super.print(updatedText,
+      if (text.trim == "scala>") ConsoleViewContentType.NORMAL_OUTPUT else contentType
+    )
   }
 }

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
@@ -55,6 +55,12 @@ class Repl(module: Module) extends ScalaLanguageConsole(module: Module) {
       initialReplWelcomeMessageHasBeenReplaced = true
     }
 
-    super.print(updatedText, contentType)
+    // In Scala 3 REPL, the "scala>" prompt is colored blue by sending appropriate ANSI sequences
+    // This is not handled correctly by Scala plugin which expects the prompt to be sent with
+    // the NORMAL_OUTPUT attributes; this breaks the REPL state machine
+    // Therefore we override the text attributes for the prompt. The only unintended consequence
+    // of this fix is that output lines equal to the prompt will also lose their text attributes.
+    super.print(updatedText, if (text.trim == "scala>")
+      ConsoleViewContentType.NORMAL_OUTPUT else contentType)
   }
 }


### PR DESCRIPTION
# Description of the PR
Removing text attributes (color) from the `scala>` prompt fixes the problem where the prompt did not appear and the overall highlighting was broken. This happened because Scala plugin expects the `scala>` prompt to be printed by the REPL process without any special formatting (text attributes), which isn't the case for Scala 3 (JDK 11+)