### PR TITLE
Added Scala 2 library as class JAR

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/Scala3Sdk.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/Scala3Sdk.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.intellij.model;
 
 import fi.aalto.cs.apluscourses.utils.content.Content;
 import fi.aalto.cs.apluscourses.utils.content.RemoteZippedDir;
+import java.util.Arrays;
 import org.jetbrains.annotations.NotNull;
 
 public class Scala3Sdk extends ScalaSdk {
@@ -29,9 +30,8 @@ public class Scala3Sdk extends ScalaSdk {
   @Override
   @NotNull
   protected String @NotNull [] getClassRoots() {
-    return new String[] {
-        "scala-library-2.13.8.jar",
-        "scala3-library_3-" + scalaVersion + ".jar"
-    };
+    return Arrays.stream(getJarFiles())
+        .filter(lib -> lib.startsWith("scala-library") || lib.startsWith("scala3-library"))
+        .toArray(String[]::new);
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/Scala3Sdk.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/Scala3Sdk.java
@@ -29,6 +29,9 @@ public class Scala3Sdk extends ScalaSdk {
   @Override
   @NotNull
   protected String @NotNull [] getClassRoots() {
-    return new String[] {"scala3-library_3-" + scalaVersion + ".jar"};
+    return new String[] {
+        "scala-library-2.13.8.jar",
+        "scala3-library_3-" + scalaVersion + ".jar"
+    };
   }
 }


### PR DESCRIPTION
# Description of the PR
Will solve the "no scala-library*.jar dependency" problem when compiling modules. Why Scala 3 requires Scala 2 as a class root is beyond me.

Hardcoding the Scala 2 version is the JAR name is definitely unsafe and should be changed, but given that O1 has settled on 3.1.3, we can be confident this won't change during O1 2022.