### PR TITLE
Autoexec REPL commands for Scala 3

### DIFF
--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
@@ -39,12 +39,7 @@ class Repl(module: Module) extends ScalaLanguageConsole(module: Module) {
 
   // We need this here because the overridden ConsoleExecuteAction needs to determine whether
   // the console is hosting a Scala 3 REPL or something else
-  val isScala3REPL: Boolean = ModuleUtils.nonEmpty(
-    ModuleRootManager.getInstance(module)
-      .orderEntries()
-      .librariesOnly()
-      .satisfying(x => x.getPresentableName.contains("scala3-") || x.getPresentableName.contains("scala-sdk-3."))
-  )
+  val isScala3REPL: Boolean = ModuleUtils.isScala3Module(module)
 
   override def print(text: String, contentType: ConsoleViewContentType): Unit = {
     var updatedText = text
@@ -57,7 +52,7 @@ class Repl(module: Module) extends ScalaLanguageConsole(module: Module) {
       // Normally, in Scala 2, we would have used the "-i" argument to pass initial REPL commands
       // Unfortunately, this has not been ported into Scala 3
       if (isScala3REPL) {
-        commands.foreach(cmd => ConsoleExecuteAction.runLine(this, cmd))
+        commands.foreach(cmd => ScalaExecutor.runLine(this, cmd))
       }
 
       initialReplWelcomeMessageHasBeenReplaced = true

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
@@ -65,7 +65,7 @@ class Repl(module: Module) extends ScalaLanguageConsole(module: Module) {
     // after every execution. We hide these prompts so as not to confuse the user
     if (remainingPromptsToSkip > 0 && text.trim == scalaPromptText) {
       remainingPromptsToSkip -= 1
-      return // scalastyle: off
+      return // scalastyle:ignore
     }
 
     // In Scala 3 REPL, the "scala>" prompt is colored blue by sending appropriate ANSI sequences

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
@@ -63,8 +63,10 @@ class Repl(module: Module) extends ScalaLanguageConsole(module: Module) {
 
     // When auto-executing commands in Scala 3 using ScalaExecutor, the prompt is printed
     // after every execution. We hide these prompts so as not to confuse the user
-    if (remainingPromptsToSkip > 0 && text.trim == scalaPromptText) {
-      remainingPromptsToSkip -= 1
+    if (remainingPromptsToSkip > 0 && (text.trim == scalaPromptText || text.trim == "")) {
+      if (text.trim == scalaPromptText) {
+        remainingPromptsToSkip -= 1
+      }
       return // scalastyle:ignore
     }
 

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/Repl.scala
@@ -8,6 +8,7 @@ import fi.aalto.cs.apluscourses.intellij.utils.ModuleUtils.{getInitialReplComman
 import fi.aalto.cs.apluscourses.intellij.utils.{ModuleUtils, ReplChangesObserver}
 import fi.aalto.cs.apluscourses.ui.ReplBannerPanel
 import org.jetbrains.plugins.scala.console.ScalaLanguageConsole
+import org.jetbrains.plugins.scala.console.apluscourses.ConsoleExecuteAction
 
 import java.awt.AWTEvent
 import java.awt.BorderLayout
@@ -52,6 +53,13 @@ class Repl(module: Module) extends ScalaLanguageConsole(module: Module) {
       && !initialReplWelcomeMessageHasBeenReplaced) {
       val commands = getInitialReplCommands(module)
       updatedText = getUpdatedText(module, commands, text)
+
+      // Normally, in Scala 2, we would have used the "-i" argument to pass initial REPL commands
+      // Unfortunately, this has not been ported into Scala 3
+      if (isScala3REPL) {
+        commands.foreach(cmd => ConsoleExecuteAction.runLine(this, cmd))
+      }
+
       initialReplWelcomeMessageHasBeenReplaced = true
     }
 

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -145,9 +145,14 @@ class ReplAction extends RunConsoleAction {
 
     var args = "-usejavacp " + getReplAdditionalArguments(module.getProject)
 
-    ModuleUtils.createInitialReplCommandsFile(module)
-    if (ModuleUtils.initialReplCommandsFileExists(module)) {
-      args += " -i " + MODULE_REPL_INITIAL_COMMANDS_FILE_NAME
+    // Scala 3 no longer has an option for preloading REPL commands, so there's no point
+    // in adding this command-line switch anymore
+    // Instead, we use an alternative method of preloading commands by using ScalaExecutor
+    if (!ModuleUtils.isScala3Module(module)) {
+      ModuleUtils.createInitialReplCommandsFile(module)
+      if (ModuleUtils.initialReplCommandsFileExists(module)) {
+        args += " -i " + MODULE_REPL_INITIAL_COMMANDS_FILE_NAME
+      }
     }
 
     configuration.setMyConsoleArgs(args)

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/utils/ModuleUtils.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/utils/ModuleUtils.scala
@@ -5,7 +5,7 @@ import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.keymap.KeymapManager
 import com.intellij.openapi.module.{Module, ModuleUtilCore}
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.roots.OrderEnumerator
+import com.intellij.openapi.roots.{ModuleRootManager, OrderEnumerator}
 import com.intellij.openapi.util.io.FileUtilRt
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings
 import fi.aalto.cs.apluscourses.utils.PluginResourceBundle.{getAndReplaceText, getText}
@@ -151,4 +151,11 @@ object ModuleUtils {
   }
 
   def isTopLevelModule(module: Module): Boolean = module.getName.equals(module.getProject.getName)
+
+  def isScala3Module(module: Module): Boolean = nonEmpty(
+    ModuleRootManager.getInstance(module)
+      .orderEntries()
+      .librariesOnly()
+      .satisfying(x => x.getPresentableName.contains("scala3-") || x.getPresentableName.contains("scala-sdk-3."))
+  )
 }

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/utils/ModuleUtils.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/utils/ModuleUtils.scala
@@ -47,13 +47,13 @@ object ModuleUtils {
 
   // O1_SPECIFIC
   def naiveValidate(@NotNull command: String): Boolean =
-    command.matches("import\\so1\\.[a-z]*(\\_|\\._)$")
+    command.matches("import\\so1\\.[a-z]*(\\*|\\.\\*)$")
 
   def clearCommands(@NotNull imports: Array[String]): Array[String] =
     imports
       .clone
       .map(_.replace("import ", ""))
-      .map(_.replace("._", ""))
+      .map(_.replace(".*", ""))
 
   def getCommandsText(@NotNull imports: Array[String]): String =
     imports.length match {

--- a/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ConsoleExecuteAction.scala
+++ b/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ConsoleExecuteAction.scala
@@ -16,9 +16,6 @@ import org.jetbrains.plugins.scala.console.ScalaConsoleInfo
 import org.jetbrains.plugins.scala.console.actions.ScalaConsoleExecuteAction
 import org.jetbrains.plugins.scala.inWriteAction
 
-import java.io.OutputStream
-import javax.swing.SwingUtilities
-
 class ConsoleExecuteAction extends ScalaConsoleExecuteAction {
   // We achieve proper multiline support by surrounding the REPL commands by special
   // ANSI sequences indicating "bracketed paste". We exploit the fact that Scala 3 REPL
@@ -101,26 +98,5 @@ class ConsoleExecuteAction extends ScalaConsoleExecuteAction {
     outputStream.flush()
 
     console.textSent(text)
-  }
-}
-
-object ConsoleExecuteAction {
-  /**
-   * Runs a single line of Scala code in the context of the provided REPL console.
-   * @param console An instance of our A+ enhanced REPL.
-   * @param command A single line (no newlines) of Scala code to execute.
-   */
-  def runLine(console: Repl, command: String): Unit = {
-    val processHandler = ScalaConsoleInfo.getProcessHandler(console.getConsoleEditor)
-    if (processHandler == null) {
-      return // scalastyle:ignore
-    }
-
-    val outputStream = processHandler.getProcessInput
-    outputStream.write((command + "\n").getBytes)
-    outputStream.flush()
-
-    // this must be invoked from EDT because it accesses the IntelliJ PSI
-    SwingUtilities.invokeLater(() => console.textSent(command))
   }
 }

--- a/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ConsoleExecuteAction.scala
+++ b/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ConsoleExecuteAction.scala
@@ -17,6 +17,7 @@ import org.jetbrains.plugins.scala.console.actions.ScalaConsoleExecuteAction
 import org.jetbrains.plugins.scala.inWriteAction
 
 import java.io.OutputStream
+import javax.swing.SwingUtilities
 
 class ConsoleExecuteAction extends ScalaConsoleExecuteAction {
   // We achieve proper multiline support by surrounding the REPL commands by special
@@ -92,7 +93,7 @@ class ConsoleExecuteAction extends ScalaConsoleExecuteAction {
 
     // the "start paste" sequence has to be in a separate write call, otherwise JLine won't
     // pick it up properly; it seems to be yet another quirk of JLine and DumbTerminal
-    val outputStream: OutputStream = processHandler.getProcessInput
+    val outputStream = processHandler.getProcessInput
     outputStream.write(BeginPaste)
     outputStream.flush()
 
@@ -100,5 +101,26 @@ class ConsoleExecuteAction extends ScalaConsoleExecuteAction {
     outputStream.flush()
 
     console.textSent(text)
+  }
+}
+
+object ConsoleExecuteAction {
+  /**
+   * Runs a single line of Scala code in the context of the provided REPL console.
+   * @param console An instance of our A+ enhanced REPL.
+   * @param command A single line (no newlines) of Scala code to execute.
+   */
+  def runLine(console: Repl, command: String): Unit = {
+    val processHandler = ScalaConsoleInfo.getProcessHandler(console.getConsoleEditor)
+    if (processHandler == null) {
+      return // scalastyle:ignore
+    }
+
+    val outputStream = processHandler.getProcessInput
+    outputStream.write((command + "\n").getBytes)
+    outputStream.flush()
+
+    // this must be invoked from EDT because it accesses the IntelliJ PSI
+    SwingUtilities.invokeLater(() => console.textSent(command))
   }
 }

--- a/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ScalaExecutor.scala
+++ b/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ScalaExecutor.scala
@@ -1,0 +1,30 @@
+// The reason for this class being in a separate package is that the runLine method
+// uses the ScalaLanguageConsole.textSent() method, which is package private. Therefore, in order to
+// call it, we must be in the same package as the console: org.jetbrains.plugins.scala.console.
+
+package org.jetbrains.plugins.scala.console.apluscourses
+
+import fi.aalto.cs.apluscourses.intellij.Repl
+import javax.swing.SwingUtilities
+import org.jetbrains.plugins.scala.console.ScalaConsoleInfo
+
+object ScalaExecutor {
+  /**
+   * Runs a single line of Scala code in the context of the provided REPL console.
+   * @param console An instance of our A+ enhanced REPL.
+   * @param command A single line (no newlines) of Scala code to execute.
+   */
+  def runLine(console: Repl, command: String): Unit = {
+    val processHandler = ScalaConsoleInfo.getProcessHandler(console.getConsoleEditor)
+    if (processHandler == null) {
+      return // scalastyle:ignore
+    }
+
+    val outputStream = processHandler.getProcessInput
+    outputStream.write((command + "\n").getBytes)
+    outputStream.flush()
+
+    // this must be invoked from EDT because it accesses the IntelliJ PSI
+    SwingUtilities.invokeLater(() => console.textSent(command))
+  }
+}

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -35,7 +35,7 @@ class CourseTest {
     List<String> autoInstallComponents = List.of(module1name);
     Map<String, String[]> replInitialCommands = new HashMap<>();
     String replAdditionalArguments = "-test";
-    replInitialCommands.put("Module1", new String[] {"import o1._"});
+    replInitialCommands.put("Module1", new String[] {"import o1.*"});
     Course course = new ModelExtensions.TestCourse(
         "13",
         "Tester Course",
@@ -79,7 +79,7 @@ class CourseTest {
         "The optional categories should be the same as those given to the constructor");
     Assertions.assertEquals(module1name, course.getAutoInstallComponents().get(0).getName(),
         "The auto-install components should be the same as those given to the constructor");
-    Assertions.assertEquals("import o1._", course.getReplInitialCommands().get("Module1")[0],
+    Assertions.assertEquals("import o1.*", course.getReplInitialCommands().get("Module1")[0],
         "The REPL initial commands for Module1 are correct.");
     Assertions.assertEquals("-test", course.getReplAdditionalArguments(),
             "The REPL arguments should be the same as that given to the constructor");
@@ -183,7 +183,7 @@ class CourseTest {
   private static final String vmOptionsJson = "\"vmOptions\":{\"a\":\"bcd\"}";
   private static final String autoInstallJson = "\"autoInstall\":[\"O1Library\"]";
   private static final String replInitialCommands = "\"repl\": {\"initialCommands\": {\"GoodStuff\": ["
-      + "\"import o1._\",\"import o1.goodstuff._\"]}}";
+      + "\"import o1.*\",\"import o1.goodstuff.*\"]}}";
   private static final String replAdditionalArgumentsJson = "\"replArguments\": \"-test\"";
   private static final String courseVersion = "\"version\": \"5.8\"";
 
@@ -217,9 +217,9 @@ class CourseTest {
         "The course should have the VM options of the configuration JSON");
     Assertions.assertEquals("O1Library", course.getAutoInstallComponents().get(0).getName(),
         "The course should have the auto-install components of the configuration JSON");
-    Assertions.assertEquals("import o1._", course.getReplInitialCommands().get("GoodStuff")[0],
+    Assertions.assertEquals("import o1.*", course.getReplInitialCommands().get("GoodStuff")[0],
         "The course should have the REPL initial commands of the configuration JSON");
-    Assertions.assertEquals("import o1.goodstuff._", course.getReplInitialCommands().get("GoodStuff")[1],
+    Assertions.assertEquals("import o1.goodstuff.*", course.getReplInitialCommands().get("GoodStuff")[1],
         "The course should have the REPL initial commands of the configuration JSON");
     Assertions.assertEquals("-test", course.getReplAdditionalArguments(),
         "The course should have the REPL arguments of the configuration JSON");


### PR DESCRIPTION
# Description of the PR
Scala 3 has removed the `-i` switch for preloading REPL commands. Very unfortunate.
So, our alternative approach: get the stdin of the REPL process and write the commands directly.
We also need to:
- make sure this doesn't occur for Scala 2
- call `ScalaLanguageConsole.textSent` so that the executed commands are reflected in the REPL's autocompletion system
- skip the `scala>` prompt for each autoexecuted command