### PR TITLE
Update fallback course to O1 2022

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -90,8 +90,8 @@ public class CourseProjectAction extends AnAction {
   private static final List<CourseItemViewModel> FALLBACK_COURSES = List.of(
       new CourseItemViewModel("Ohjelmointistudio 2 / Programming Studio A", "Spring 2022",
           "https://gitmanager.cs.aalto.fi/static/studio2_k2022dev2-horrible-gitmanager-interface/projects/s2_course_config.json"),
-      new CourseItemViewModel("O1", "Fall 2021",
-          "https://gitmanager.cs.aalto.fi/static/O1_2021/projects/o1_course_config.json")
+      new CourseItemViewModel("O1", "Fall 2022",
+          "https://gitmanager.cs.aalto.fi/static/O1_2022/modules/o1_course_config.json")
   );
 
   /**


### PR DESCRIPTION
# Description of the PR
Updated the O1 course in fallback list from 2021 to 2022