### PR TITLE
Fixed a bug related to tree path encoder.

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/utils/TreePathEncoder.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/utils/TreePathEncoder.java
@@ -1,16 +1,36 @@
 package fi.aalto.cs.apluscourses.ui.utils;
 
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import javax.swing.tree.TreePath;
 import org.jetbrains.annotations.Nullable;
 
 public abstract class TreePathEncoder<T> {
-  private final ConcurrentMap<TreePath, T> map = new ConcurrentHashMap<>();
 
+  // Note: ConcurrentHashMap doesn't work as a memoization map for recursive functions.
+  // It might not be strictly necessary to use synchronized map here,
+  // reconsider the issue if this some day becomes a performance bottleneck.
+  private final Map<TreePath, T> memo = Collections.synchronizedMap(new HashMap<>());
+
+  /**
+   * Encodes the given tree path to a code of type T.
+   *
+   * @param treePath A tree path.
+   * @return An object of type T that is a code for the given tree path.
+   */
   public T encode(@Nullable TreePath treePath) {
-    return treePath == null ? emptyCode()
-        : map.computeIfAbsent(treePath, this::encodeInternal);
+    if (treePath == null) {
+      return emptyCode();
+    }
+    T value = memo.get(treePath);
+    if (value == null) {
+      value =  encodeInternal(treePath);
+      // In parallel execution, it might happen that the value is calculated twice.
+      // That doesn't, however, matter in the sense of correctness.
+      memo.put(treePath, value);
+    }
+    return value;
   }
 
   private T encodeInternal(TreePath treePath) {

--- a/src/test/java/fi/aalto/cs/apluscourses/ui/utils/TreePathEncoderTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/ui/utils/TreePathEncoderTest.java
@@ -1,9 +1,11 @@
 package fi.aalto.cs.apluscourses.ui.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import javax.swing.tree.TreePath;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 class TreePathEncoderTest {
@@ -21,10 +23,16 @@ class TreePathEncoderTest {
 
   @Test
   void testEncode() {
-    TreePathEncoder<String> encoder = new TestTreePathEncoder();
-    TreePath path = new TreePath(new Object[] {"foo", "bar", "baz"});
-    String code = encoder.encode(path);
+    TreePathEncoder<String> encoder = spy(new TestTreePathEncoder());
+    TreePath path1 = new TreePath(new Object[] {"foo", "bar", "baz"});
+    TreePath path2 = new TreePath(new Object[] {"foo", "bar", 2000});
 
-    Assertions.assertEquals("/foo/bar/baz", code);
+    String code1 = encoder.encode(path1);
+    String code2 = encoder.encode(path2);
+
+    assertEquals("/foo/bar/baz", code1);
+    assertEquals("/foo/bar/2000", code2);
+
+    verify(encoder, times(1)).encodeNode("/foo", "bar");
   }
 }


### PR DESCRIPTION
# Description of the PR

Error reported with the following stack trace:

<details>
  <summary>Stack trace</summary>

  ```
java.lang.IllegalStateException: Recursive update
	at java.base/java.util.concurrent.ConcurrentHashMap.transfer(ConcurrentHashMap.java:2552)
	at java.base/java.util.concurrent.ConcurrentHashMap.tryPresize(ConcurrentHashMap.java:2415)
	at java.base/java.util.concurrent.ConcurrentHashMap.treeifyBin(ConcurrentHashMap.java:2669)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1768)
	at fi.aalto.cs.apluscourses.ui.utils.TreePathEncoder.encode(TreePathEncoder.java:13)
	at fi.aalto.cs.apluscourses.ui.utils.TreePathEncoder.encodeInternal(TreePathEncoder.java:17)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1708)
	at fi.aalto.cs.apluscourses.ui.utils.TreePathEncoder.encode(TreePathEncoder.java:13)
	at fi.aalto.cs.apluscourses.ui.base.TreeView.lambda$restoreExpandedState$0(TreeView.java:156)
	at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:178)
	at java.base/java.util.stream.Streams$StreamBuilderImpl.forEachRemaining(Streams.java:411)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:734)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:276)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:276)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:762)
	at java.base/java.util.stream.ReferencePipeline$7$1.accept(ReferencePipeline.java:276)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:133)
	at java.base/java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1845)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)
	at java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at fi.aalto.cs.apluscourses.ui.base.TreeView.restoreExpandedState(TreeView.java:157)
	at fi.aalto.cs.apluscourses.ui.base.TreeView.update(TreeView.java:121)
	at fi.aalto.cs.apluscourses.ui.base.TreeView.setViewModel(TreeView.java:95)
	at fi.aalto.cs.apluscourses.ui.exercise.ExercisesView$ExercisesTreeView.setViewModel(ExercisesView.java:139)
	at fi.aalto.cs.apluscourses.ui.exercise.ExercisesView.lambda$viewModelChanged$0(ExercisesView.java:78)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:194)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:881)
	at com.intellij.openapi.application.impl.ApplicationImpl$3.run(ApplicationImpl.java:513)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:75)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:118)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:42)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:779)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:730)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:724)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:749)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:918)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:766)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$6(IdeEventQueue.java:450)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:791)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$7(IdeEventQueue.java:449)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueue.performActivity(IdeEventQueue.java:624)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:447)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:881)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:493)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
  ```
</details>

The problem was that `TreePathEncoder` used `ConcurrentHashMap` to memoize a recursive function, which that class does not support (the issue was unclear still in Java 8). This PR fixes the bug.