### PR TITLE
Fix RestartableTask

### DIFF
--- a/src/test/java/fi/aalto/cs/apluscourses/utils/RestartableTaskTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/utils/RestartableTaskTest.java
@@ -1,0 +1,26 @@
+package fi.aalto.cs.apluscourses.utils;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class RestartableTaskTest {
+
+  @Test
+  void testRestart() throws InterruptedException {
+    int max = 10;
+    AtomicInteger num = new AtomicInteger(max);
+    RestartableTask task = new RestartableTask(
+        // Threads' sleeping times 9 sec, 8 sec, 7 sec, ..., 0 sec
+        () -> Thread.sleep(num.getAndDecrement() * 1000L),
+        null);
+    Thread[] threads = new Thread[max];
+    for (int i = 0; i < max; i++) {
+      threads[i] = task.restart();
+    }
+    threads[max - 1].join();
+    assertTrue(Arrays.stream(threads).noneMatch(Thread::isAlive));
+  }
+}


### PR DESCRIPTION
# Description of the PR

This class is used with filtering. Previously, there was a change that if a task is repeatedly restarted quick enough, some invocations are not interrupted and let finish before the next invocation starts (which should always happen; that's the idea of the class). This should fix it.

The apparent error was not known to cause any real-life issues. In theory, it could have led to some inconsistent filtering results in exercises/modules.