### PR TITLE
Refresh VFS after importing Scala SDK

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJLibrary.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJLibrary.java
@@ -73,6 +73,7 @@ public abstract class IntelliJLibrary
 
     library.commit();
     libraryTable.commit();
+    VirtualFileManager.getInstance().syncRefresh();
   }
 
   @Override


### PR DESCRIPTION
# Description of the PR
This enables instantaneous indexing of Scala SDK upon creating an A+ project (and should fix the missing "Run" button)