### PR TITLE
Validate token on a separate thread

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/Component.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Component.java
@@ -7,7 +7,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public abstract class Component {
   public static final int NOT_INSTALLED = StateMonitor.INITIAL;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/base/BaseListViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/base/BaseListViewModel.java
@@ -5,7 +5,6 @@ import fi.aalto.cs.apluscourses.presentation.filter.FilterEngine;
 import fi.aalto.cs.apluscourses.presentation.filter.Filterable;
 import fi.aalto.cs.apluscourses.presentation.filter.Options;
 import fi.aalto.cs.apluscourses.utils.CollectionUtil;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/APlusAuthenticationView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/APlusAuthenticationView.java
@@ -89,11 +89,14 @@ public class APlusAuthenticationView extends DialogWrapper implements Dialog {
         lastValidationResult = new ValidationInfo(getText("ui.authenticationView.connectionError"),
             inputField).withOKEnabled();
       } finally {
-        enableDialog(true);
-        showValidationResult(lastValidationResult);
-        if (lastValidationResult == null) {
-          ApplicationManager.getApplication().invokeLater(() -> close(OK_EXIT_CODE), ModalityState.any());
-        }
+        final ValidationInfo finalLastValidationResult = lastValidationResult;
+        ApplicationManager.getApplication().invokeLater(() -> {
+          enableDialog(true);
+          showValidationResult(finalLastValidationResult);
+          if (finalLastValidationResult == null) {
+            close(OK_EXIT_CODE);
+          }
+        }, ModalityState.any());
       }
     });
   }


### PR DESCRIPTION
# Description of the PR
If a user opened the "Set A+ Token" dialog, entered a token and pressed OK, but the network connection was faulty, the whole IntelliJ was blocked on the modal box while the validation process waited for a timeout (which might never come)

This PR changes the A+ Token dialog to the following:
1. When the user presses OK, the textbox and OK button is disabled
2. Token is validated on a separate thread; validation result is displayed as soon as the thread finishes
3. At any point the user can press Cancel to interrupt the operation (the background network request won't really be interrupted, but since it doesn't change any state, it's not a big deal)