### PR TITLE
Reduce submission resulting polling intervals

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionStatusUpdater.java
@@ -43,11 +43,11 @@ public class SubmissionStatusUpdater {
 
   private long totalTime;
 
-  // 10 seconds in milliseconds
-  private static final long DEFAULT_INTERVAL = 10L * 1000;
-
   // 5 seconds in milliseconds
-  private static final long DEFAULT_INCREMENT = 5L * 1000;
+  private static final long DEFAULT_INTERVAL = 5L * 1000;
+
+  // 2 seconds in milliseconds
+  private static final long DEFAULT_INCREMENT = 2L * 1000;
 
   // 3 minutes in milliseconds
   private static final long DEFAULT_TIME_LIMIT = 3L * 60 * 1000;


### PR DESCRIPTION
# Description of the PR
Initial delay reduced from 10 to 5 seconds, subsequent delay increment reduced from 5 to 2 seconds.