### PR TITLE
Fix null handling on JSON field being null

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionInfo.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionInfo.java
@@ -41,8 +41,8 @@ public class SubmissionInfo {
 
     for (int i = 0; i < formSpec.length(); ++i) {
       JSONObject spec = formSpec.getJSONObject(i);
-      String type = spec.getString("type");
-      if (!type.equals("file")) {
+      String type = spec.optString("type");
+      if (!"file".equals(type)) {
         continue;
       }
 


### PR DESCRIPTION
# Description of the PR
Fixes #986 in cases when the exercise type is null. We don't really mind the null value, but the JSON library certainly does.