### PR TITLE
Added automatic cache eviction through course configuration file

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
@@ -68,8 +68,9 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
   /**
    * Default constructor.
    */
-  public APlusExerciseDataSource(@NotNull String apiUrl, @NotNull Path cacheFile) {
+  public APlusExerciseDataSource(@NotNull String apiUrl, @NotNull Path cacheFile, long courseLastModified) {
     var dataAccess = new DefaultDataAccess(new DualCache<>(new JsonFileCache(cacheFile)));
+    dataAccess.updateCacheExpiration(courseLastModified);
     this.client = dataAccess;
     this.parser = dataAccess;
     this.apiUrl = apiUrl;
@@ -135,6 +136,11 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
   @Override
   public void clearCache() {
     client.clearCache();
+  }
+
+  @Override
+  public void updateCacheExpiration(long courseLastModified) {
+    client.updateCacheExpiration(courseLastModified);
   }
 
   /**
@@ -407,6 +413,11 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
     @Override
     public void clearCache() {
       cache.clearAll();
+    }
+
+    @Override
+    public void updateCacheExpiration(long courseLastModified) {
+      cache.updateExpirationTimestamp(courseLastModified);
     }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/dal/Client.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/Client.java
@@ -24,4 +24,6 @@ public interface Client {
               @NotNull Map<String, Object> data) throws IOException;
 
   default void clearCache() {}
+
+  default void updateCacheExpiration(long courseLastModified) {}
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/CourseUpdater.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/CourseUpdater.java
@@ -119,7 +119,7 @@ public class CourseUpdater extends RepeatedTask {
     JSONObject newCourseConfig = null;
     try {
       newCourseConfig = fetchCourseConfiguration();
-    } catch (IOException e) {
+    } catch (JSONException | IOException e) {
       progress.finish();
       return;
     }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -65,7 +65,8 @@ public class IntelliJCourse extends Course {
                         @NotNull CommonLibraryProvider commonLibraryProvider,
                         @NotNull Map<Long, Tutorial> tutorials,
                         @Nullable String feedbackParser,
-                        @Nullable String newsParser) {
+                        @Nullable String newsParser,
+                        long courseLastModified) {
     super(
         id,
         name,
@@ -83,13 +84,14 @@ public class IntelliJCourse extends Course {
         courseVersion,
         tutorials,
         feedbackParser,
-        newsParser);
+        newsParser,
+        courseLastModified);
 
     this.project = project;
     this.commonLibraryProvider = commonLibraryProvider;
     this.platformListener = new PlatformListener();
     this.exerciseDataSource = new APlusExerciseDataSource(getApiUrl(), project.getBasePath()
-        .resolve(Paths.get(Project.DIRECTORY_STORE_FOLDER, "a-plus-cache.json")));
+        .resolve(Paths.get(Project.DIRECTORY_STORE_FOLDER, "a-plus-cache.json")), courseLastModified);
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -54,13 +54,14 @@ public class IntelliJModelFactory implements ModelFactory {
                              @NotNull Version courseVersion,
                              @NotNull Map<Long, Tutorial> tutorials,
                              @Nullable String feedbackParser,
-                             @Nullable String newsParser) {
+                             @Nullable String newsParser,
+                             long courseLastModified) {
 
     IntelliJCourse course =
         new IntelliJCourse(id, name, aplusUrl, languages, modules, libraries, exerciseModules,
             resourceUrls, vmOptions, optionalCategories, autoInstallComponentNames, replInitialCommands,
             replAdditionalArguments, courseVersion, project, new CommonLibraryProvider(project), tutorials,
-            feedbackParser, newsParser);
+            feedbackParser, newsParser, courseLastModified);
 
     Component.InitializationCallback componentInitializationCallback =
         component -> registerComponentToCourse(component, course);

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -89,6 +89,8 @@ public abstract class Course implements ComponentSource {
   @Nullable
   private final String newsParser;
 
+  private long courseLastModified;
+
   /**
    * Constructs a course with the given parameters.
    *
@@ -115,7 +117,8 @@ public abstract class Course implements ComponentSource {
                    @NotNull Version courseVersion,
                    @NotNull Map<Long, Tutorial> tutorials,
                    @Nullable String feedbackParser,
-                   @Nullable String newsParser) {
+                   @Nullable String newsParser,
+                   long courseLastModified) {
     this.id = id;
     this.name = name;
     this.aplusUrl = aplusUrl;
@@ -135,6 +138,7 @@ public abstract class Course implements ComponentSource {
     this.replInitialCommands = replInitialCommands;
     this.replAdditionalArguments = replAdditionalArguments;
     this.courseVersion = courseVersion;
+    this.courseLastModified = courseLastModified;
   }
 
   @NotNull
@@ -193,6 +197,7 @@ public abstract class Course implements ComponentSource {
     Map<Long, Tutorial> tutorials = getTutorials(jsonObject);
     String feedbackParser = jsonObject.optString("feedbackParser", null);
     String newsParser = jsonObject.optString("newsParser", null);
+    long courseLastModified = jsonObject.optLong("courseLastModified");
     return factory.createCourse(
         courseId,
         courseName,
@@ -210,7 +215,8 @@ public abstract class Course implements ComponentSource {
         courseVersion,
         tutorials,
         feedbackParser,
-        newsParser
+        newsParser,
+        courseLastModified
     );
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
@@ -68,4 +68,6 @@ public interface ExerciseDataSource {
       throws IOException;
 
   default void clearCache() {}
+
+  default void updateCacheExpiration(long courseLastModified) {}
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
@@ -26,7 +26,8 @@ public interface ModelFactory {
                       @NotNull Version courseVersion,
                       @NotNull Map<Long, Tutorial> tutorials,
                       @Nullable String feedbackParser,
-                      @NotNull String newsParser);
+                      @NotNull String newsParser,
+                      long courseLastModified);
 
   Module createModule(@NotNull String name, @NotNull URL url, @NotNull Version version,
                       @NotNull String changelog);

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/cache/Cache.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/cache/Cache.java
@@ -9,4 +9,6 @@ public interface Cache<K, V> {
   void putValue(K key, V value, @NotNull CachePreference cachePreference);
 
   void clearAll();
+
+  void updateExpirationTimestamp(long expirationTimestamp);
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/cache/CacheImpl.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/cache/CacheImpl.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.Nullable;
 public class CacheImpl<K, V> implements Cache<K, V> {
   private @NotNull Map<K, CacheEntry<V>> entries = new HashMap<>();
   private final @NotNull Object lock = new Object();
+  private long expirationTimestamp = 0;
 
   @Nullable
   protected CacheEntry<V> getEntry(K key) {
@@ -40,6 +41,7 @@ public class CacheImpl<K, V> implements Cache<K, V> {
     var entry = getEntry(key);
     return entry == null
         || entry.getCreationTime().plus(cachePreference.allowedCacheAge).isBefore(ZonedDateTime.now())
+        || entry.getCreationTime().toEpochSecond() < expirationTimestamp
         ? null : entry.getValue();
   }
 
@@ -55,5 +57,10 @@ public class CacheImpl<K, V> implements Cache<K, V> {
     synchronized (lock) {
       entries.clear();
     }
+  }
+
+  @Override
+  public void updateExpirationTimestamp(long expirationTimestamp) {
+    this.expirationTimestamp = expirationTimestamp;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/cache/DualCache.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/cache/DualCache.java
@@ -36,4 +36,10 @@ public class DualCache<K, V> implements Cache<K, V> {
     longTimeCache.clearAll();
     shortTimeCache.clearAll();
   }
+
+  @Override
+  public void updateExpirationTimestamp(long expirationTimestamp) {
+    longTimeCache.updateExpirationTimestamp(expirationTimestamp);
+    shortTimeCache.updateExpirationTimestamp(expirationTimestamp);
+  }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSourceTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSourceTest.java
@@ -54,7 +54,7 @@ class APlusExerciseDataSourceTest {
   @Test
   void testDefaultConstructor() {
     var exerciseDataSource = new APlusExerciseDataSource(
-        url, Paths.get(FileUtilRt.getTempDirectory()));
+        url, Paths.get(FileUtilRt.getTempDirectory()), 0);
     Assertions.assertEquals(url, exerciseDataSource.getApiUrl());
     Assertions.assertTrue(exerciseDataSource.getClient() instanceof APlusExerciseDataSource.DefaultDataAccess);
     Assertions.assertTrue(exerciseDataSource.getParser() instanceof APlusExerciseDataSource.DefaultDataAccess);

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -155,7 +155,7 @@ public class ModelExtensions {
       super(id, name, aplusUrl, languages, modules, libraries, exerciseModules, resourceUrls, vmOptions,
           optionalCategories, autoInstallComponentNames, replInitialCommands,
           replAdditionalArguments, courseVersion, tutorials, null,
-          "default");
+          "default", 0);
       exerciseDataSource = new TestExerciseDataSource();
     }
 
@@ -198,7 +198,7 @@ public class ModelExtensions {
           // courseVersion
           BuildInfo.INSTANCE.courseVersion,
           // tutorials
-          Collections.emptyMap(), null, "default");
+          Collections.emptyMap(), null, "default", 0);
       this.exerciseDataSource = exerciseDataSource;
     }
 
@@ -256,7 +256,8 @@ public class ModelExtensions {
           // tutorials
           Collections.emptyMap(),
           null,
-          null);
+          null,
+          0);
     }
   }
 
@@ -436,7 +437,8 @@ public class ModelExtensions {
                                @NotNull Version courseVersion,
                                @NotNull Map<Long, Tutorial> tutorials,
                                @Nullable String feedbackParser,
-                               @Nullable String newsParser) {
+                               @Nullable String newsParser,
+                               long courseLastModified) {
       return new ModelExtensions.TestCourse(
           id,
           name,


### PR DESCRIPTION
# Description of the PR
Fixes #988 by adding an optional field to the course configuration file called "courseLastModified". This is a long integer, representing a Unix timestamp (in seconds) when the course data was last updated. Any cached entries created before this timestamp will be ignored.

Note: I'm not particularly proud of this solution, mainly because:
- the initial expiration date should be passed to the Cache constructor instead of immediately calling `updateCacheExpiration` (my excuse: given the inheritance hierarchy of the CacheImpl class, the current solution is much shorter and achieves the same result)
- the cache should really be (in my opinion) just a key-value mapping, and it shouldn't be dealing with expiration and stuff (this should be a task for the CoursesClient, but we already have a "refactor cache" issue sitting somewhere)
- it assumes that the clock on the user's machine is set correctly (which nowadays should be a given, though)

It should be a decent solution to solve the immediate problem and get the release going, though.