### PR TITLE
Change semicolon position in ignored file list

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/ProjectViewUtil.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/ProjectViewUtil.java
@@ -21,6 +21,6 @@ public class ProjectViewUtil {
                                              @NotNull Project project) {
     FileTypeManager fileTypeManager = FileTypeManager.getInstance();
     WriteCommandAction.runWriteCommandAction(project, () -> fileTypeManager
-        .setIgnoredFilesList(fileTypeManager.getIgnoredFilesList() + ignoredFileName + ";"));
+        .setIgnoredFilesList(fileTypeManager.getIgnoredFilesList() + ";" + ignoredFileName));
   }
 }


### PR DESCRIPTION
# Description of the PR
Fixes #996 - the previous implementation added a semicolon in the wrong spot.