### PR TITLE
Multilanguage exercises

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
@@ -152,11 +152,13 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
   @Override
   @NotNull
   public List<ExerciseGroup> getExerciseGroups(@NotNull Course course,
-                                               @NotNull Authentication authentication)
+                                               @NotNull Authentication authentication,
+                                               @NotNull String languageCode)
       throws IOException {
     String url = apiUrl + COURSES + "/" + course.getId() + "/" + EXERCISES + "/";
     var exerciseOrder = getExerciseOrder(course, authentication);
-    return getPaginatedResults(url, authentication, object -> ExerciseGroup.fromJsonObject(object, exerciseOrder));
+    return getPaginatedResults(url, authentication,
+        object -> ExerciseGroup.fromJsonObject(object, exerciseOrder, languageCode));
   }
 
   /**
@@ -201,10 +203,11 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
                               @NotNull Set<String> optionalCategories,
                               @NotNull Map<Long, Tutorial> tutorials,
                               @NotNull Authentication authentication,
-                              @NotNull CachePreference cachePreference) throws IOException {
+                              @NotNull CachePreference cachePreference,
+                              @NotNull String languageCode) throws IOException {
     var url = apiUrl + "exercises/" + exerciseId + "/";
     var response = client.fetch(url, authentication, cachePreference);
-    return parser.parseExercise(response, points, optionalCategories, tutorials);
+    return parser.parseExercise(response, points, optionalCategories, tutorials, languageCode);
   }
 
   @Override
@@ -387,8 +390,9 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
     public Exercise parseExercise(@NotNull JSONObject jsonObject,
                                   @NotNull Points points,
                                   @NotNull Set<String> optionalCategories,
-                                  @NotNull Map<Long, Tutorial> tutorials) {
-      return Exercise.fromJsonObject(jsonObject, points, optionalCategories, tutorials);
+                                  @NotNull Map<Long, Tutorial> tutorials,
+                                  @NotNull String languageCode) {
+      return Exercise.fromJsonObject(jsonObject, points, optionalCategories, tutorials, languageCode);
     }
 
     @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/dal/Parser.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/Parser.java
@@ -35,7 +35,8 @@ public interface Parser {
   Exercise parseExercise(@NotNull JSONObject jsonObject,
                          @NotNull Points points,
                          @NotNull Set<String> optionalCategories,
-                         @NotNull Map<Long, Tutorial> tutorials);
+                         @NotNull Map<Long, Tutorial> tutorials,
+                         @NotNull String languageCode);
 
   SubmissionResult parseSubmissionResult(@NotNull JSONObject jsonObject,
                                          @NotNull Exercise exercise,

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -231,8 +231,14 @@ public class CourseProjectAction extends AnAction {
 
     if (useCourseFile) {
       // The course file not created in testing.
-      var courseProject = new CourseProject(course, courseUrl, project, notifier);
-      PluginSettings.getInstance().registerCourseProject(courseProject);
+      var currentProject = PluginSettings.getInstance().getCourseProject(project);
+      if (currentProject != null) {
+        currentProject.getCourseUpdater().restart();
+        currentProject.getExercisesUpdater().restart();
+      } else {
+        var courseProject = new CourseProject(course, courseUrl, project, notifier);
+        PluginSettings.getInstance().registerCourseProject(courseProject);
+      }
     }
 
     Future<?> autoInstallDone = executor.submit(() -> startAutoInstalls(course, project));

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ShowFeedbackAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ShowFeedbackAction.java
@@ -130,8 +130,7 @@ public class ShowFeedbackAction extends AnAction {
           .findFirst()
           .ifPresent(editor -> fileEditorManager.closeFile(Objects.requireNonNull(editor.getFile())));
       HTMLEditorProvider.openEditor(project, getAndReplaceText("ui.ShowFeedbackAction.feedbackTitle",
-              APlusLocalizationUtil.getEnglishName(submissionResult.getExercise().getName()),
-              String.valueOf(submissionResult.getId())),
+              submissionResult.getExercise().getName(), String.valueOf(submissionResult.getId())),
           document.html());
     } catch (IOException ex) {
       notifier.notify(new NetworkErrorNotification(ex), project);

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotification.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotification.java
@@ -31,8 +31,7 @@ public class FeedbackAvailableNotification extends Notification {
         PluginSettings.A_PLUS,
         getText("notification.FeedbackAvailableNotification.title"),
         getAndReplaceText("notification.FeedbackAvailableNotification.content",
-            APlusLocalizationUtil.getEnglishName(exercise.getName()),
-            SubmissionResultUtil.getStatus(submissionResult)),
+            exercise.getName(), SubmissionResultUtil.getStatus(submissionResult)),
         NotificationType.INFORMATION
     );
     if (mainViewModelProvider.getMainViewModel(project).getFeedbackCss() != null) {

--- a/src/main/java/fi/aalto/cs/apluscourses/model/DummyExercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/DummyExercise.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.model;
 
+import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import java.util.OptionalLong;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,10 +27,11 @@ public class DummyExercise extends Exercise {
    * Constructs a DummyExercise from a JsonObject.
    */
   @NotNull
-  public static DummyExercise fromJsonObject(@NotNull JSONObject jsonObject) {
+  public static DummyExercise fromJsonObject(@NotNull JSONObject jsonObject,
+                                             @NotNull String languageCode) {
     long id = jsonObject.getLong("id");
 
-    String name = jsonObject.getString("display_name");
+    String name = APlusLocalizationUtil.getLocalizedName(jsonObject.getString("display_name"), languageCode);
     String htmlUrl = jsonObject.getString("html_url");
 
     int maxPoints = jsonObject.getInt("max_points");

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.model;
 
+import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -81,10 +82,11 @@ public class Exercise implements Browsable {
   public static Exercise fromJsonObject(@NotNull JSONObject jsonObject,
                                         @NotNull Points points,
                                         @NotNull Set<String> optionalCategories,
-                                        @NotNull Map<Long, Tutorial> tutorials) {
+                                        @NotNull Map<Long, Tutorial> tutorials,
+                                        @NotNull String languageCode) {
     long id = jsonObject.getLong("id");
 
-    String name = jsonObject.getString("display_name");
+    String name = APlusLocalizationUtil.getLocalizedName(jsonObject.getString("display_name"), languageCode);
     String htmlUrl = jsonObject.getString("html_url");
 
     var bestSubmissionId = points.getBestSubmissionIds().get(id);

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
@@ -17,7 +17,8 @@ public interface ExerciseDataSource {
 
   @NotNull
   List<ExerciseGroup> getExerciseGroups(@NotNull Course course,
-                                        @NotNull Authentication authentication) throws IOException;
+                                        @NotNull Authentication authentication,
+                                        @NotNull String languageCode) throws IOException;
 
   @NotNull
   Points getPoints(@NotNull Course course, @NotNull Authentication authentication)
@@ -33,7 +34,8 @@ public interface ExerciseDataSource {
                        @NotNull Set<String> optionalCategories,
                        @NotNull Map<Long, Tutorial> tutorials,
                        @NotNull Authentication authentication,
-                       @NotNull CachePreference cachePreference) throws IOException;
+                       @NotNull CachePreference cachePreference,
+                       @NotNull String languageCode) throws IOException;
 
   @NotNull
   String getSubmissionFeedback(long submissionId,

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseGroup.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseGroup.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.model;
 
+import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import fi.aalto.cs.apluscourses.utils.JsonUtil;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,15 +56,16 @@ public class ExerciseGroup implements Browsable {
    */
   @NotNull
   public static ExerciseGroup fromJsonObject(@NotNull JSONObject jsonObject,
-                                             @NotNull Map<Long, List<Long>> exerciseOrder) {
+                                             @NotNull Map<Long, List<Long>> exerciseOrder,
+                                             @NotNull String languageCode) {
     long id = jsonObject.getLong("id");
-    String name = jsonObject.getString("display_name");
+    String name = APlusLocalizationUtil.getLocalizedName(jsonObject.getString("display_name"), languageCode);
     String htmlUrl = jsonObject.getString("html_url");
     boolean isOpen = jsonObject.getBoolean("is_open");
     JSONArray exercisesArray = jsonObject.getJSONArray("exercises");
     DummyExercise[] dummyExercises = JsonUtil.parseArray(exercisesArray,
         JSONArray::getJSONObject,
-        DummyExercise::fromJsonObject,
+        (obj) -> DummyExercise.fromJsonObject(obj, languageCode),
         DummyExercise[]::new);
     return new ExerciseGroup(id, name, htmlUrl, isOpen, Arrays.stream(dummyExercises).collect(Collectors.toList()),
         exerciseOrder.get(id));

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModel.java
@@ -33,7 +33,7 @@ public class ExerciseGroupViewModel extends SelectableNodeViewModel<ExerciseGrou
   }
 
   public String getPresentableName() {
-    return APlusLocalizationUtil.getEnglishName(getModel().getName());
+    return getModel().getName();
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
@@ -93,7 +93,7 @@ public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> impleme
    */
   @NotNull
   public String getStatusText() {
-    if ("Feedback".equals(getPresentableName())) { // O1_SPECIFIC
+    if ("Feedback".equals(getPresentableName()) || "Palaute".equals(getPresentableName())) { // O1_SPECIFIC
       return "";
     }
     if (getStatus() == Status.OPTIONAL_PRACTICE) {

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
@@ -26,7 +26,7 @@ public class ExerciseViewModel extends SelectableNodeViewModel<Exercise> impleme
   }
 
   public String getPresentableName() {
-    return APlusLocalizationUtil.getEnglishName(getModel().getName());
+    return getModel().getName();
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
@@ -79,7 +79,7 @@ public class SubmissionViewModel {
 
   @NotNull
   public String getPresentableExerciseName() {
-    return APlusLocalizationUtil.getEnglishName(exercise.getName());
+    return exercise.getName();
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/ideactivities/TutorialViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/ideactivities/TutorialViewModel.java
@@ -153,7 +153,7 @@ public class TutorialViewModel implements Task.Observer {
   }
 
   public @NotNull String getTitle() {
-    return APlusLocalizationUtil.getEnglishName(tutorialExercise.getName());
+    return tutorialExercise.getName();
   }
 
   public @NotNull Tutorial getTutorial() {

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/APlusLocalizationUtil.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/APlusLocalizationUtil.java
@@ -7,27 +7,21 @@ import org.jetbrains.annotations.Nullable;
 
 public class APlusLocalizationUtil {
 
-  /**
-   * Parses the English name from the given string, or returns the string if the string contains
-   * no localization. An example of a valid string is {@code "|en:hello|fi:terve|"}.
-   *
-   * @param name A string with a name in multiple languages, or just a single name.
-   */
-  @NotNull
-  public static String getEnglishName(@NotNull String name) {
-    String englishName = StringUtils.substringBetween(name, "|en:", "|");
-    // The name seems to not contain localization
-    return Objects.requireNonNullElse(englishName, name);
-  }
-
   private static String extractLocalizedText(@NotNull String localizedString, @NotNull String languageCode) {
     return StringUtils.substringBetween(localizedString, "|" + languageCode + ":", "|");
   }
 
+  /**
+   * Parses the given localized string and returns the text corresponding to the specified language.
+   * If the entry in the requested language does not exist, the method attempts to localize the string in English.
+   * If that fails too, the whole raw string is returned.
+   * An example of a valid localized string is {@code "|en:hello|fi:terve|"}.
+   *
+   * @param localizedString The input string, which may be localized or not.
+   * @param languageCode The requested language code, e.g. "fi" or "en".
+   */
   @NotNull
   public static String getLocalizedName(@NotNull String localizedString, @NotNull String languageCode) {
-    // First, try to get the text in the requested language. If that fails, try English.
-    // If that fails too, return the raw string.
     return Objects.requireNonNullElse(extractLocalizedText(localizedString, languageCode),
         Objects.requireNonNullElse(extractLocalizedText(localizedString, "en"), localizedString));
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/APlusLocalizationUtil.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/APlusLocalizationUtil.java
@@ -3,6 +3,7 @@ package fi.aalto.cs.apluscourses.utils;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class APlusLocalizationUtil {
 
@@ -17,6 +18,18 @@ public class APlusLocalizationUtil {
     String englishName = StringUtils.substringBetween(name, "|en:", "|");
     // The name seems to not contain localization
     return Objects.requireNonNullElse(englishName, name);
+  }
+
+  private static String extractLocalizedText(@NotNull String localizedString, @NotNull String languageCode) {
+    return StringUtils.substringBetween(localizedString, "|" + languageCode + ":", "|");
+  }
+
+  @NotNull
+  public static String getLocalizedName(@NotNull String localizedString, @NotNull String languageCode) {
+    // First, try to get the text in the requested language. If that fails, try English.
+    // If that fails too, return the raw string.
+    return Objects.requireNonNullElse(extractLocalizedText(localizedString, languageCode),
+        Objects.requireNonNullElse(extractLocalizedText(localizedString, "en"), localizedString));
   }
 
   /**

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseActionTest.java
@@ -147,7 +147,7 @@ class SubmitExerciseActionTest {
     course = spy(new ModelExtensions.TestCourse("91", "NineOne Course", exerciseDataSource));
     doReturn(groups).when(exerciseDataSource).getGroups(course, authentication);
     doReturn(points).when(exerciseDataSource).getPoints(course, authentication);
-    doReturn(exerciseGroups).when(exerciseDataSource).getExerciseGroups(course, authentication);
+    doReturn(exerciseGroups).when(exerciseDataSource).getExerciseGroups(course, authentication, "en");
     doReturn("http://localhost:1000")
         .when(exerciseDataSource)
         .submit(any(Submission.class), any(Authentication.class));

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseGroupTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseGroupTest.java
@@ -57,20 +57,20 @@ class ExerciseGroupTest {
   void testFromJsonObject() {
     JSONObject json = new JSONObject()
         .put(ID_KEY, 567)
-        .put(NAME_KEY, "group name")
+        .put(NAME_KEY, "|abcd:group name|")
         .put(HTML_KEY, "http://example.com/w01")
         .put(OPEN_KEY, true)
         .put(EXERCISES_KEY, new JSONArray()
             .put(new JSONObject()
                 .put(ID_KEY, 567)
-                .put(NAME_KEY, "exercise name")
+                .put(NAME_KEY, "|fi:harjoituksen nimi|en:exercise name|")
                 .put(HTML_KEY, "http://localhost:7000")
                 .put(MAX_POINTS_KEY, 50)
                 .put(MAX_SUBMISSIONS_KEY, 10)));
-    ExerciseGroup group = ExerciseGroup.fromJsonObject(json, Map.of(567L, List.of()));
+    ExerciseGroup group = ExerciseGroup.fromJsonObject(json, Map.of(567L, List.of()), "en");
 
     Assertions.assertEquals(567, group.getId());
-    Assertions.assertEquals("group name", group.getName(),
+    Assertions.assertEquals("|abcd:group name|", group.getName(),
         "The exercise group has the same name as in the JSON object");
     Assertions.assertEquals("http://example.com/w01", group.getHtmlUrl());
     Assertions.assertTrue(group.isOpen());
@@ -82,7 +82,7 @@ class ExerciseGroupTest {
   void testFromJsonObjectMissingExercises() {
     JSONObject json = new JSONObject().put(NAME_KEY, "group test name");
     assertThrows(JSONException.class, () ->
-        ExerciseGroup.fromJsonObject(json, new HashMap<>()));
+        ExerciseGroup.fromJsonObject(json, new HashMap<>(), "en"));
   }
 
   @Test
@@ -90,7 +90,7 @@ class ExerciseGroupTest {
     JSONObject json = new JSONObject()
         .put(ID_KEY, 100);
     assertThrows(JSONException.class, () ->
-        ExerciseGroup.fromJsonObject(json, new HashMap<>()));
+        ExerciseGroup.fromJsonObject(json, new HashMap<>(), "en"));
   }
 
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ExerciseTest.java
@@ -59,14 +59,15 @@ class ExerciseTest {
   void testExerciseFromJsonObject() {
     JSONObject json = new JSONObject()
         .put(ID_KEY, 11L)
-        .put(NAME_KEY, "Cool name")
+        .put(NAME_KEY, "|en:Cool name|")
         .put(HTML_KEY, "http://localhost:1000")
         .put(MAX_POINTS_KEY, 99)
         .put(MAX_SUBMISSIONS_KEY, 5)
         .put(DIFFICULTY_KEY, "ha")
         .put("additional key", "which shouldn't cause errors");
 
-    Exercise exercise = Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptySet(), Collections.emptyMap());
+    Exercise exercise = Exercise.fromJsonObject(json, TEST_POINTS,
+        Collections.emptySet(), Collections.emptyMap(), "fi");
     exercise.addSubmissionResult(
         new SubmissionResult(2, 0, 0.0, SubmissionResult.Status.GRADED, exercise));
 
@@ -93,7 +94,7 @@ class ExerciseTest {
         .put(MAX_SUBMISSIONS_KEY, 3);
 
     assertThrows(JSONException.class, () ->
-        Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptySet(), Collections.emptyMap()));
+        Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptySet(), Collections.emptyMap(), "fi"));
   }
 
   @Test
@@ -105,7 +106,7 @@ class ExerciseTest {
         .put(MAX_SUBMISSIONS_KEY, 4);
 
     assertThrows(JSONException.class, () ->
-        Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptySet(), Collections.emptyMap()));
+        Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptySet(), Collections.emptyMap(), "fi"));
   }
 
   @Test
@@ -117,7 +118,7 @@ class ExerciseTest {
         .put(MAX_SUBMISSIONS_KEY, 4);
 
     assertThrows(JSONException.class, () ->
-        Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptySet(), Collections.emptyMap()));
+        Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptySet(), Collections.emptyMap(), "fi"));
   }
 
   @Test
@@ -129,7 +130,7 @@ class ExerciseTest {
         .put(MAX_POINTS_KEY, 4);
 
     assertThrows(JSONException.class, () ->
-        Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptySet(), Collections.emptyMap()));
+        Exercise.fromJsonObject(json, TEST_POINTS, Collections.emptySet(), Collections.emptyMap(), "fi"));
   }
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -45,7 +45,8 @@ public class ModelExtensions {
     @NotNull
     @Override
     public List<ExerciseGroup> getExerciseGroups(@NotNull Course course,
-                                                 @NotNull Authentication authentication) {
+                                                 @NotNull Authentication authentication,
+                                                 @NotNull String languageCode) {
       return Collections.emptyList();
     }
 
@@ -76,7 +77,8 @@ public class ModelExtensions {
                                 @NotNull Set<String> optionalCategories,
                                 @NotNull Map<Long, Tutorial> tutorials,
                                 @NotNull Authentication authentication,
-                                @NotNull CachePreference cachePreference) {
+                                @NotNull CachePreference cachePreference,
+                                @NotNull String languageCode) {
       return new Exercise(1, "lol", "http://example.com",
           new SubmissionInfo(Collections.emptyMap()), 20, 10, OptionalLong.empty(), null, false
       );

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModelTest.java
@@ -19,7 +19,7 @@ class ExerciseGroupViewModelTest {
 
   @Test
   void testGetPresentableName() {
-    var group1 = new ExerciseGroup(1, "|fi:Ryhma|en:Group|", "", true, List.of(), List.of());
+    var group1 = new ExerciseGroup(1, "Group", "", true, List.of(), List.of());
     ExerciseGroupViewModel viewModel1 = new ExerciseGroupViewModel(group1);
 
     var group2 = new ExerciseGroup(2, "group name", "", true, List.of(), List.of());

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModelTest.java
@@ -17,7 +17,7 @@ class ExerciseViewModelTest {
     var info = new SubmissionInfo(Collections.emptyMap());
 
     Exercise exercise1 = new Exercise(
-        123, "|en:Assignment|fi:Tehtava|", "http://localhost:1000", info, 0, 0,
+        123, "Assignment", "http://localhost:1000", info, 0, 0,
         OptionalLong.empty(), null, false);
     ExerciseViewModel viewModel1 = new ExerciseViewModel(exercise1);
 

--- a/src/test/java/fi/aalto/cs/apluscourses/utils/APlusLocalizationUtilTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/utils/APlusLocalizationUtilTest.java
@@ -6,17 +6,25 @@ import org.junit.jupiter.api.Test;
 class APlusLocalizationUtilTest {
 
   @Test
-  void testGetEnglishName() {
-    String multilingualName = "|fi:hei|en:hello|se:hej|";
-    Assertions.assertEquals("hello", APlusLocalizationUtil.getEnglishName(multilingualName),
-        "Correctly parses the English name");
-  }
+  void testGetLocalizedName() {
+    String multilingualName = "|fi:hei|en:hello|se:och samma på svenska|";
+    Assertions.assertEquals("hei", APlusLocalizationUtil.getLocalizedName(multilingualName, "fi"),
+        "Correctly parses the localized name in Finnish");
+    Assertions.assertEquals("hello", APlusLocalizationUtil.getLocalizedName(multilingualName, "en"),
+        "Correctly parses the localized name in English");
+    Assertions.assertEquals("och samma på svenska", APlusLocalizationUtil.getLocalizedName(multilingualName, "se"),
+        "Correctly parses the localized name in Swedish");
+    Assertions.assertEquals("hello", APlusLocalizationUtil.getLocalizedName(multilingualName, "ee"),
+        "Correctly returns the English text if the request language is unavailable");
 
-  @Test
-  void testGetEnglishNameWithoutLocalization() {
-    String name = "abcdefg";
-    Assertions.assertEquals("abcdefg", APlusLocalizationUtil.getEnglishName(name),
-        "Returns the given string when the string doesn't contain localization");
+    String nonEnglishText = "|fi:antauduttuaan|";
+    Assertions.assertEquals("antauduttuaan", APlusLocalizationUtil.getLocalizedName(nonEnglishText, "fi"),
+        "Correctly parses the localized name in Finnish");
+    Assertions.assertEquals(nonEnglishText, APlusLocalizationUtil.getLocalizedName(nonEnglishText, "lv"),
+        "Correctly returns the whole text if neither the requested nor English versions are available");
+
+    Assertions.assertEquals("xyz", APlusLocalizationUtil.getLocalizedName("xyz", "en"),
+        "Correctly returns the whole text if there is no localization information");
   }
 
   @Test


### PR DESCRIPTION
# Description of the PR
Fixes #964
When fetching the exercises, the plugin now shows them in the correct language (the one that the user has selected when linking the A+ course)

Why I haven't used the `MultiLanguageText` pattern suggested in the issue description? While that approach would have been more "object-oriented", I see no benefit in using such a class in this situation:
- This would be a nice feature if the plugin needed to display the texts in multiple language simultaneously, but it doesn't. Even if the user changes the course language, all exercises are constructed anew, so a potential `MultiLanguageText::get(language)` would only be called with a single possible argument value.
- The current way is much easier to implement - pass the language to the object constructor and that's it. With the `MultiLanguageText` pattern, one would need to pass the language around to all places where the text is displayed, including obscure places such as TreeView search callbacks.
- News are already implemented that way. (Although I noticed this only after I wrote this PR. It even seems I unknowingly used the same variable names as Jaakko with his news implementation. Great minds think alike, it seems)