### PR TITLE
Check for presence of third-party dependencies

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -29,7 +29,6 @@ import fi.aalto.cs.apluscourses.ui.InstallerDialogs;
 import fi.aalto.cs.apluscourses.ui.courseproject.CourseProjectActionDialogs;
 import fi.aalto.cs.apluscourses.ui.courseproject.CourseProjectActionDialogsImpl;
 import fi.aalto.cs.apluscourses.ui.ideactivities.ComponentDatabase;
-import fi.aalto.cs.apluscourses.ui.utils.PluginInstallerCallback;
 import fi.aalto.cs.apluscourses.ui.utils.PluginInstallerDialogs;
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ShowFeedbackAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ShowFeedbackAction.java
@@ -17,7 +17,6 @@ import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.intellij.utils.Interfaces;
 import fi.aalto.cs.apluscourses.model.SubmissionResult;
 import fi.aalto.cs.apluscourses.presentation.exercise.ExercisesTreeViewModel;
-import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -30,6 +30,7 @@ import fi.aalto.cs.apluscourses.ui.utils.PluginInstallerDialogs;
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
 import fi.aalto.cs.apluscourses.utils.PluginAutoInstaller;
+import fi.aalto.cs.apluscourses.utils.PluginIntegrityChecker;
 import fi.aalto.cs.apluscourses.utils.Version;
 import fi.aalto.cs.apluscourses.utils.observable.ObservableProperty;
 import fi.aalto.cs.apluscourses.utils.observable.ObservableReadWriteProperty;
@@ -66,6 +67,11 @@ public class InitializationActivity implements Background {
   public void runActivity(@NotNull Project project) {
     var courseVersion = BuildInfo.INSTANCE.courseVersion;
     logger.info("Starting initialization, course version {}", courseVersion);
+    if (!PluginIntegrityChecker.isPluginCorrectlyInstalled()) {
+      logger.warn("Missing one or more dependencies");
+      return;
+    }
+
     PluginSettings pluginSettings = PluginSettings.getInstance();
     pluginSettings.initializeLocalIdeSettings();
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -67,10 +67,10 @@ public class InitializationActivity implements Background {
   public void runActivity(@NotNull Project project) {
     var courseVersion = BuildInfo.INSTANCE.courseVersion;
     logger.info("Starting initialization, course version {}", courseVersion);
-    ApplicationManager.getApplication().invokeLater(IntegrityCheckDialog::show);
+
     if (!PluginIntegrityChecker.isPluginCorrectlyInstalled()) {
       logger.warn("Missing one or more dependencies");
-      return;
+      ApplicationManager.getApplication().invokeLater(IntegrityCheckDialog::show);
     }
 
     PluginSettings pluginSettings = PluginSettings.getInstance();

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -25,7 +25,7 @@ import fi.aalto.cs.apluscourses.intellij.utils.ProjectViewUtil;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.MalformedCourseConfigurationException;
 import fi.aalto.cs.apluscourses.model.UnexpectedResponseException;
-import fi.aalto.cs.apluscourses.ui.utils.PluginInstallerCallback;
+import fi.aalto.cs.apluscourses.ui.IntegrityCheckDialog;
 import fi.aalto.cs.apluscourses.ui.utils.PluginInstallerDialogs;
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
@@ -67,6 +67,7 @@ public class InitializationActivity implements Background {
   public void runActivity(@NotNull Project project) {
     var courseVersion = BuildInfo.INSTANCE.courseVersion;
     logger.info("Starting initialization, course version {}", courseVersion);
+    ApplicationManager.getApplication().invokeLater(IntegrityCheckDialog::show);
     if (!PluginIntegrityChecker.isPluginCorrectlyInstalled()) {
       logger.warn("Missing one or more dependencies");
       return;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotification.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/notifications/FeedbackAvailableNotification.java
@@ -12,7 +12,6 @@ import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.SubmissionResult;
-import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import fi.aalto.cs.apluscourses.utils.SubmissionResultUtil;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseGroupViewModel.java
@@ -4,7 +4,6 @@ import fi.aalto.cs.apluscourses.model.ExerciseGroup;
 import fi.aalto.cs.apluscourses.model.ExercisesLazyLoader;
 import fi.aalto.cs.apluscourses.presentation.base.Searchable;
 import fi.aalto.cs.apluscourses.presentation.base.SelectableNodeViewModel;
-import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/ExerciseViewModel.java
@@ -5,7 +5,6 @@ import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.TutorialExercise;
 import fi.aalto.cs.apluscourses.presentation.base.Searchable;
 import fi.aalto.cs.apluscourses.presentation.base.SelectableNodeViewModel;
-import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import fi.aalto.cs.apluscourses.utils.CollectionUtil;
 import java.util.Collections;
 import java.util.List;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/exercise/SubmissionViewModel.java
@@ -7,7 +7,6 @@ import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.Group;
 import fi.aalto.cs.apluscourses.model.Submission;
 import fi.aalto.cs.apluscourses.model.SubmittableFile;
-import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
 import fi.aalto.cs.apluscourses.utils.FileDateFormatter;
 import fi.aalto.cs.apluscourses.utils.observable.ObservableProperty;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/ideactivities/TutorialViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/ideactivities/TutorialViewModel.java
@@ -5,7 +5,6 @@ import fi.aalto.cs.apluscourses.model.Tutorial;
 import fi.aalto.cs.apluscourses.model.TutorialExercise;
 import fi.aalto.cs.apluscourses.model.task.ActivityFactory;
 import fi.aalto.cs.apluscourses.model.task.Task;
-import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/AboutDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/AboutDialog.java
@@ -77,17 +77,17 @@ public class AboutDialog extends DialogWrapper {
     var about = createAboutTextLabel();
     var authors = createAuthorsTextLabel();
     var attributes = createAttributesTextLabel();
-    LinkLabel<Object> linkLabel = createPluginWebsiteLinkLabel();
-    LinkLabel<Object> linkLabelGithub = createGithubWebsiteLinkLabel();
-    LinkLabel<Object> linkLabelAPlus = createAPlusWebsiteLinkLabel();
-    var items = List.of(version, about, authors, attributes, linkLabel, linkLabelGithub, linkLabelAPlus);
+    LinkLabel<Object> linkLabelPlugin = createLinkLabel(getText("ui.aboutDialog.website"), A_COURSES_PLUGIN_PAGE);
+    LinkLabel<Object> linkLabelGithub = createLinkLabel(getText("ui.aboutDialog.GithubWebsite"), GITHUB_PAGE);
+    LinkLabel<Object> linkLabelAPlus = createLinkLabel(getText("ui.aboutDialog.APlusWebsite"), A_PLUS_PAGE);
+    var items = List.of(version, about, authors, attributes, linkLabelPlugin, linkLabelGithub, linkLabelAPlus);
     items.forEach(item -> item.setAlignmentX(Component.LEFT_ALIGNMENT));
     box.add(createFiller());
     box.add(version);
     box.add(createFiller());
     box.add(about);
     box.add(createFiller());
-    box.add(linkLabel);
+    box.add(linkLabelPlugin);
     box.add(linkLabelGithub);
     box.add(linkLabelAPlus);
     box.add(createFiller());
@@ -129,38 +129,9 @@ public class AboutDialog extends DialogWrapper {
   }
 
   @NotNull
-  private LinkLabel<Object> createPluginWebsiteLinkLabel() {
-    LinkLabel<Object> linkLabel = new LinkLabel<>(
-        getText("ui.aboutDialog.website"),
-        AllIcons.Ide.External_link_arrow,
-        (first, second) ->
-            BrowserUtil.browse(A_COURSES_PLUGIN_PAGE));
-    linkLabel.setIconTextGap(0);
-    linkLabel.setHorizontalTextPosition(SwingConstants.LEFT);
-
-    return linkLabel;
-  }
-
-  @NotNull
-  private LinkLabel<Object> createAPlusWebsiteLinkLabel() {
-    LinkLabel<Object> linkLabel = new LinkLabel<>(
-        getText("ui.aboutDialog.APlusWebsite"),
-        AllIcons.Ide.External_link_arrow,
-        (first, second) ->
-            BrowserUtil.browse(A_PLUS_PAGE));
-    linkLabel.setIconTextGap(0);
-    linkLabel.setHorizontalTextPosition(SwingConstants.LEFT);
-
-    return linkLabel;
-  }
-
-  @NotNull
-  private LinkLabel<Object> createGithubWebsiteLinkLabel() {
-    LinkLabel<Object> linkLabel = new LinkLabel<>(
-        getText("ui.aboutDialog.GithubWebsite"),
-        AllIcons.Ide.External_link_arrow,
-        (first, second) ->
-            BrowserUtil.browse(GITHUB_PAGE));
+  private LinkLabel<Object> createLinkLabel(@NotNull String text, @NotNull String link) {
+    LinkLabel<Object> linkLabel = new LinkLabel<>(text, AllIcons.Ide.External_link_arrow,
+        (first, second) -> BrowserUtil.browse(link));
     linkLabel.setIconTextGap(0);
     linkLabel.setHorizontalTextPosition(SwingConstants.LEFT);
 

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
@@ -1,5 +1,7 @@
 package fi.aalto.cs.apluscourses.ui;
 
+import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
+
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ui.components.JBLabel;
@@ -11,21 +13,27 @@ import javax.swing.SwingConstants;
 
 public class IntegrityCheckDialog {
 
+  private IntegrityCheckDialog() {
+
+  }
+
+  /**
+   * Displays a dialog notifying the user that the plugin's required dependencies are missing.
+   */
   public static void show() {
     var box = Box.createVerticalBox();
 
-    JBLabel message = new JBLabel("<html>The A+ Courses plugin has detected that critical IntelliJ dependencies are missing. The plugin will not function without them.<br>This situation could have been caused by installing the plugin directly from disk, rather than using the JetBrains Marketplace.<br>Please reinstall the plugin from the Marketplace.");
-
-    LinkLabel<Object> linkLabel = new LinkLabel<>("See detailed instructions at A+ Courses GitHub", AllIcons.Ide.External_link_arrow,
-        (first, second) -> BrowserUtil.browse("https://github.com/Aalto-LeTech/aplus-courses/wiki/Installing-from-Marketplace"));
+    LinkLabel<Object> linkLabel = new LinkLabel<>(getText("ui.integrityDialog.linkText"),
+        AllIcons.Ide.External_link_arrow,
+        (first, second) -> BrowserUtil.browse(getText("ui.integrityDialog.linkTarget")));
     linkLabel.setIconTextGap(0);
     linkLabel.setHorizontalTextPosition(SwingConstants.LEFT);
 
-    box.add(message);
+    box.add(new JBLabel(getText("ui.integrityDialog.description")));
     box.add(Box.createVerticalStrut(10));
     box.add(linkLabel);
 
-    JOptionPane.showMessageDialog(null, JBUI.Panels.simplePanel(box), "A+ Courses: Missing dependencies", JOptionPane.ERROR_MESSAGE);
+    JOptionPane.showMessageDialog(null, JBUI.Panels.simplePanel(box), getText("ui.integrityDialog.title"),
+        JOptionPane.ERROR_MESSAGE);
   }
-
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
@@ -1,0 +1,4 @@
+package fi.aalto.cs.apluscourses.ui;
+
+public class IntegrityCheckDialog {
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
@@ -1,4 +1,31 @@
 package fi.aalto.cs.apluscourses.ui;
 
+import com.intellij.icons.AllIcons;
+import com.intellij.ide.BrowserUtil;
+import com.intellij.ui.components.JBLabel;
+import com.intellij.ui.components.labels.LinkLabel;
+import com.intellij.util.ui.JBUI;
+import javax.swing.Box;
+import javax.swing.JOptionPane;
+import javax.swing.SwingConstants;
+
 public class IntegrityCheckDialog {
+
+  public static void show() {
+    var box = Box.createVerticalBox();
+
+    JBLabel message = new JBLabel("<html>The A+ Courses plugin has detected that critical IntelliJ dependencies are missing. The plugin will not function without them.<br>This situation could have been caused by installing the plugin directly from disk, rather than using the JetBrains Marketplace.<br>Please reinstall the plugin from the Marketplace.");
+
+    LinkLabel<Object> linkLabel = new LinkLabel<>("See detailed instructions at A+ Courses GitHub", AllIcons.Ide.External_link_arrow,
+        (first, second) -> BrowserUtil.browse("https://github.com/Aalto-LeTech/aplus-courses/wiki/Installing-from-Marketplace"));
+    linkLabel.setIconTextGap(0);
+    linkLabel.setHorizontalTextPosition(SwingConstants.LEFT);
+
+    box.add(message);
+    box.add(Box.createVerticalStrut(10));
+    box.add(linkLabel);
+
+    JOptionPane.showMessageDialog(null, JBUI.Panels.simplePanel(box), "A+ Courses: Missing dependencies", JOptionPane.ERROR_MESSAGE);
+  }
+
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/APlusLocalizationUtil.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/APlusLocalizationUtil.java
@@ -3,7 +3,6 @@ package fi.aalto.cs.apluscourses.utils;
 import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class APlusLocalizationUtil {
 

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/PluginIntegrityChecker.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/PluginIntegrityChecker.java
@@ -12,10 +12,11 @@ public class PluginIntegrityChecker {
    */
   public static boolean isPluginCorrectlyInstalled() {
     try {
+      // reference the dependencies' classes; an exception will be thrown if any of these is missing
       return !ZipFile.class.toString().isEmpty() && !JSONObject.class.toString().isEmpty()
           && !Safelist.class.toString().isEmpty() && !HttpClient.class.toString().isEmpty();
-    } catch (Exception ignored) {
-      // the potential exception here is some kind of ReflectiveOperationException, which
+    } catch (Throwable ignored) {
+      // the potential exception here is usually NoClassDefFoundError, which
       // could only be caused by a missing class (= missing dependency)
     }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/PluginIntegrityChecker.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/PluginIntegrityChecker.java
@@ -1,0 +1,28 @@
+package fi.aalto.cs.apluscourses.utils;
+
+import net.lingala.zip4j.ZipFile;
+import org.apache.http.client.HttpClient;
+import org.json.JSONObject;
+import org.jsoup.safety.Safelist;
+
+public class PluginIntegrityChecker {
+
+  /**
+   * Checks if A+ Courses' required dependencies are correctly installed and available.
+   */
+  public static boolean isPluginCorrectlyInstalled() {
+    try {
+      return !ZipFile.class.toString().isEmpty() && !JSONObject.class.toString().isEmpty()
+          && !Safelist.class.toString().isEmpty() && !HttpClient.class.toString().isEmpty();
+    } catch (Exception ignored) {
+      // the potential exception here is some kind of ReflectiveOperationException, which
+      // could only be caused by a missing class (= missing dependency)
+    }
+
+    return false;
+  }
+
+  private PluginIntegrityChecker() {
+
+  }
+}

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -181,7 +181,10 @@ ui.authenticationView.invalidToken=The token is invalid
 ui.authenticationView.connectionError=A network error has occurred
 ui.authenticationView.tokenLink=What is my token?
 ### Integrity check failed dialog
-ui.integrityDialog.title=Missing Dependencies
+ui.integrityDialog.description=<html>The A+ Courses plugin has detected that critical IntelliJ dependencies are missing. The plugin will not function without them.<br>This situation could have been caused by installing the plugin directly from disk, rather than using the JetBrains Marketplace.<br>Please reinstall the plugin from the Marketplace.</html>
+ui.integrityDialog.title=A+ Courses: Missing dependencies
+ui.integrityDialog.linkText=See detailed instructions at A+ Courses GitHub
+ui.integrityDialog.linkTarget=https://github.com/Aalto-LeTech/aplus-courses/wiki/Installing-from-Marketplace
 ### About dialog
 ui.aboutDialog.description=The A+ Courses plugin supports the educational use of IntelliJ (and its Scala plugin) in programming courses that rely on the A+ learning management system, which has been developed at Aalto University.\n\nThe plugin accesses programming assignments and automated grading services provided by A+ and otherwise enhances the student experience.
 ui.aboutDialog.title=A+ Courses

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -180,6 +180,8 @@ ui.authenticationView.noEmptyToken=The token cannot be empty
 ui.authenticationView.invalidToken=The token is invalid
 ui.authenticationView.connectionError=A network error has occurred
 ui.authenticationView.tokenLink=What is my token?
+### Integrity check failed dialog
+ui.integrityDialog.title=Missing Dependencies
 ### About dialog
 ui.aboutDialog.description=The A+ Courses plugin supports the educational use of IntelliJ (and its Scala plugin) in programming courses that rely on the A+ learning management system, which has been developed at Aalto University.\n\nThe plugin accesses programming assignments and automated grading services provided by A+ and otherwise enhances the student experience.
 ui.aboutDialog.title=A+ Courses
@@ -187,7 +189,7 @@ ui.aboutDialog.website=A+ Courses plugin website
 ui.aboutDialog.version=<html><b>Version: {0}</b></html>
 ui.aboutDialog.authors=Developed by the department of Computer Science at Aalto University.
 ui.aboutDialog.APlusWebsite=A+ website
-ui.aboutDialog.GithubWebsite=A+ courses plugin gitHub
+ui.aboutDialog.GithubWebsite=A+ Courses plugin GitHub
 ui.aboutDialog.attributes=<html><div>The plugin uses the following 3<sup style='font-size:8px'>rd</sup> party libraries:<ul><li><a href="https://commons.apache.org/proper/commons-io/">Apache Commons IO</a></li><li><a href="https://plugins.jetbrains.com/plugin/1347-scala">IntelliJ Scala Plugin</a></li><li><a href="https://www.json.org/json-en.html">json.org</a></li><li><a href="https://jsoup.org/">jsoup</a></li><li><a href="https://www.scala-lang.org/api/current/">Scala Standard Library</a></li><li><a href="https://github.com/srikanth-lingala/zip4j">zip4j</a></li></ul></div></html>
 ### Select student dialog
 ui.selectStudentDialog.title=Select Student


### PR DESCRIPTION
# Description of the PR
_**Note: do not merge** until the message box & wiki page wording is discussed during a weekly_

Closes #965
During plugin's initialization, the plugin will attempt to reference classes related to all 3rd party dependencies and show a message box if they happen to be missing.

![msg](https://user-images.githubusercontent.com/73069541/232824549-a7b1c078-c84d-429a-8c87-4f6606f2baa0.png)
