### PR TITLE
Exercise hiding rules in course configuration file

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -19,6 +19,7 @@ import fi.aalto.cs.apluscourses.model.ExerciseDataSource;
 import fi.aalto.cs.apluscourses.model.Library;
 import fi.aalto.cs.apluscourses.model.Module;
 import fi.aalto.cs.apluscourses.model.Tutorial;
+import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import fi.aalto.cs.apluscourses.utils.Version;
 import java.net.URL;
@@ -66,6 +67,7 @@ public class IntelliJCourse extends Course {
                         @NotNull CommonLibraryProvider commonLibraryProvider,
                         @NotNull Map<Long, Tutorial> tutorials,
                         @NotNull List<PluginDependency> pluginDependencies,
+                        @NotNull CourseHiddenElements hiddenElements,
                         @Nullable String feedbackParser,
                         @Nullable String newsParser,
                         long courseLastModified) {
@@ -86,6 +88,7 @@ public class IntelliJCourse extends Course {
         courseVersion,
         tutorials,
         pluginDependencies,
+        hiddenElements,
         feedbackParser,
         newsParser
     );

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -9,6 +9,7 @@ import fi.aalto.cs.apluscourses.model.ModelFactory;
 import fi.aalto.cs.apluscourses.model.Module;
 import fi.aalto.cs.apluscourses.model.ModuleMetadata;
 import fi.aalto.cs.apluscourses.model.Tutorial;
+import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import fi.aalto.cs.apluscourses.utils.Version;
 import java.net.URL;
@@ -55,6 +56,7 @@ public class IntelliJModelFactory implements ModelFactory {
                              @NotNull Version courseVersion,
                              @NotNull Map<Long, Tutorial> tutorials,
                              @NotNull List<PluginDependency> pluginDependencies,
+                             @NotNull CourseHiddenElements hiddenElements,
                              @Nullable String feedbackParser,
                              @Nullable String newsParser,
                              long courseLastModified) {
@@ -63,7 +65,7 @@ public class IntelliJModelFactory implements ModelFactory {
         new IntelliJCourse(id, name, aplusUrl, languages, modules, libraries, exerciseModules,
             resourceUrls, vmOptions, optionalCategories, autoInstallComponentNames, replInitialCommands,
             replAdditionalArguments, courseVersion, project, new CommonLibraryProvider(project), tutorials,
-            pluginDependencies, feedbackParser, newsParser, courseLastModified);
+            pluginDependencies, hiddenElements, feedbackParser, newsParser, courseLastModified);
 
     Component.InitializationCallback componentInitializationCallback =
         component -> registerComponentToCourse(component, course);

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.model;
 
+import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import fi.aalto.cs.apluscourses.utils.Version;
 import java.net.URL;
@@ -27,6 +28,7 @@ public interface ModelFactory {
                       @NotNull Version courseVersion,
                       @NotNull Map<Long, Tutorial> tutorials,
                       @NotNull List<PluginDependency> pluginDependencies,
+                      @NotNull CourseHiddenElements hiddenElements,
                       @Nullable String feedbackParser,
                       @NotNull String newsParser,
                       long courseLastModified);

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/CourseHiddenElements.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/CourseHiddenElements.java
@@ -1,0 +1,79 @@
+package fi.aalto.cs.apluscourses.utils;
+
+import fi.aalto.cs.apluscourses.model.MalformedCourseConfigurationException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class CourseHiddenElements {
+
+  private final @NotNull List<Integer> hiddenIDs = new ArrayList<>();
+
+  private final @NotNull List<String> hiddenRegexes = new ArrayList<>();
+
+  private final @NotNull Map<String, List<String>> hiddenLanguageSpecificRegexes = new HashMap<>();
+
+  @NotNull
+  public static CourseHiddenElements fromJsonObject(@NotNull JSONArray hiddenEntriesArray) {
+    List<Integer> hiddenIDs = new ArrayList<>();
+    List<String> hiddenRegexes = new ArrayList<>();
+    Map<String, List<String>> hiddenLanguageSpecificRegexes = new HashMap<>();
+
+    for (int i = 0; i < hiddenEntriesArray.length(); ++i) {
+      JSONObject entryInfo = hiddenEntriesArray.getJSONObject(i);
+
+      int hiddenID = entryInfo.optInt("byId", -1);
+      if (hiddenID != -1) {
+        // Hide by exercise/group ID
+        hiddenIDs.add(hiddenID);
+        continue;
+      }
+
+      Object hiddenRegex = entryInfo.get("byRegex");
+      if (hiddenRegex instanceof String) {
+        // Hide by language-independent regex
+        hiddenRegexes.add((String) hiddenRegex);
+        continue;
+      } else if (hiddenRegex instanceof JSONObject) {
+        // Hide by language-dependent regex
+        JSONObject hiddenRegexObject = (JSONObject)hiddenRegex;
+        for (String key : hiddenRegexObject.keySet()) {
+          String regex = hiddenRegexObject.getString(key);
+          hiddenLanguageSpecificRegexes.computeIfAbsent(key, k -> new ArrayList<>()).add(regex);
+        }
+
+        continue;
+      }
+
+      throw new JSONException("Element number " + i + " in the \"hiddenEntries\" array is of an unsupported format");
+    }
+
+    return new CourseHiddenElements(hiddenIDs, hiddenRegexes, hiddenLanguageSpecificRegexes);
+  }
+
+  public CourseHiddenElements() {
+    this(null, null, null);
+  }
+
+  public CourseHiddenElements(@Nullable List<Integer> hiddenIDs,
+                              @Nullable List<String> hiddenRegexes,
+                              @Nullable Map<String, List<String>> hiddenLanguageSpecificRegexes) {
+    if (hiddenIDs != null) {
+      this.hiddenIDs.addAll(hiddenIDs);
+    }
+
+    if (hiddenRegexes != null) {
+      this.hiddenRegexes.addAll(hiddenRegexes);
+    }
+
+    if (hiddenLanguageSpecificRegexes != null) {
+      this.hiddenLanguageSpecificRegexes.putAll(hiddenLanguageSpecificRegexes);
+    }
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/CourseHiddenElements.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/CourseHiddenElements.java
@@ -20,14 +20,21 @@ public class CourseHiddenElements {
 
   private final @NotNull Map<String, List<Pattern>> hiddenLanguageSpecificRegexes = new HashMap<>();
 
+  /**
+   * Constructs the CourseHiddenElements object from an array of JSON objects.
+   * Each JSON object must either have a "byId" integer-valued element (in order to
+   * hide the element by its ID), a "byRegex" string-valued element (to hide the element
+   * by a case-insensitive regex match), or a "byRegex" object-valued element (same as string,
+   * but language-specific).
+   */
   @NotNull
-  public static CourseHiddenElements fromJsonObject(@NotNull JSONArray hiddenEntriesArray) {
+  public static CourseHiddenElements fromJsonObject(@NotNull JSONArray hiddenElementsArray) {
     List<Long> hiddenIDs = new ArrayList<>();
     List<Pattern> hiddenRegexes = new ArrayList<>();
     Map<String, List<Pattern>> hiddenLanguageSpecificRegexes = new HashMap<>();
 
-    for (int i = 0; i < hiddenEntriesArray.length(); ++i) {
-      JSONObject entryInfo = hiddenEntriesArray.getJSONObject(i);
+    for (int i = 0; i < hiddenElementsArray.length(); ++i) {
+      JSONObject entryInfo = hiddenElementsArray.getJSONObject(i);
 
       long hiddenID = entryInfo.optLong("byId", -1);
       if (hiddenID != -1) {
@@ -43,7 +50,7 @@ public class CourseHiddenElements {
         continue;
       } else if (hiddenRegex instanceof JSONObject) {
         // Hide by language-dependent regex
-        JSONObject hiddenRegexObject = (JSONObject)hiddenRegex;
+        JSONObject hiddenRegexObject = (JSONObject) hiddenRegex;
         for (String key : hiddenRegexObject.keySet()) {
           String regex = hiddenRegexObject.getString(key);
 
@@ -54,12 +61,17 @@ public class CourseHiddenElements {
         continue;
       }
 
-      throw new JSONException("Element number " + i + " in the \"hiddenEntries\" array is of an unsupported format");
+      throw new JSONException("Element number " + i + " in the \"hiddenElements\" array is of an unsupported format");
     }
 
     return new CourseHiddenElements(hiddenIDs, hiddenRegexes, hiddenLanguageSpecificRegexes);
   }
 
+  /**
+   * Checks if the object (e.g. exercise) ID or string match at least one of hiding rules.
+   *
+   * @return True of the object is supposed to be hidden, false otherwise.
+   */
   public boolean shouldHideObject(long objectId, @NotNull String objectName, @Nullable String currentLanguage) {
     if (hiddenIDs.contains(objectId)) {
       return true;
@@ -73,10 +85,16 @@ public class CourseHiddenElements {
         .stream().anyMatch(r -> r.matcher(objectName).find());
   }
 
+  /**
+   * Constructor without any hiding rules.
+   */
   public CourseHiddenElements() {
     this(null, null, null);
   }
 
+  /**
+   * Constructor.
+   */
   public CourseHiddenElements(@Nullable List<Long> hiddenIDs,
                               @Nullable List<Pattern> hiddenRegexes,
                               @Nullable Map<String, List<Pattern>> hiddenLanguageSpecificRegexes) {

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/CourseHiddenElements.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/CourseHiddenElements.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.json.JSONArray;
@@ -13,22 +14,22 @@ import org.json.JSONObject;
 
 public class CourseHiddenElements {
 
-  private final @NotNull List<Integer> hiddenIDs = new ArrayList<>();
+  private final @NotNull List<Long> hiddenIDs = new ArrayList<>();
 
-  private final @NotNull List<String> hiddenRegexes = new ArrayList<>();
+  private final @NotNull List<Pattern> hiddenRegexes = new ArrayList<>();
 
-  private final @NotNull Map<String, List<String>> hiddenLanguageSpecificRegexes = new HashMap<>();
+  private final @NotNull Map<String, List<Pattern>> hiddenLanguageSpecificRegexes = new HashMap<>();
 
   @NotNull
   public static CourseHiddenElements fromJsonObject(@NotNull JSONArray hiddenEntriesArray) {
-    List<Integer> hiddenIDs = new ArrayList<>();
-    List<String> hiddenRegexes = new ArrayList<>();
-    Map<String, List<String>> hiddenLanguageSpecificRegexes = new HashMap<>();
+    List<Long> hiddenIDs = new ArrayList<>();
+    List<Pattern> hiddenRegexes = new ArrayList<>();
+    Map<String, List<Pattern>> hiddenLanguageSpecificRegexes = new HashMap<>();
 
     for (int i = 0; i < hiddenEntriesArray.length(); ++i) {
       JSONObject entryInfo = hiddenEntriesArray.getJSONObject(i);
 
-      int hiddenID = entryInfo.optInt("byId", -1);
+      long hiddenID = entryInfo.optLong("byId", -1);
       if (hiddenID != -1) {
         // Hide by exercise/group ID
         hiddenIDs.add(hiddenID);
@@ -38,14 +39,16 @@ public class CourseHiddenElements {
       Object hiddenRegex = entryInfo.get("byRegex");
       if (hiddenRegex instanceof String) {
         // Hide by language-independent regex
-        hiddenRegexes.add((String) hiddenRegex);
+        hiddenRegexes.add(Pattern.compile((String) hiddenRegex, Pattern.CASE_INSENSITIVE));
         continue;
       } else if (hiddenRegex instanceof JSONObject) {
         // Hide by language-dependent regex
         JSONObject hiddenRegexObject = (JSONObject)hiddenRegex;
         for (String key : hiddenRegexObject.keySet()) {
           String regex = hiddenRegexObject.getString(key);
-          hiddenLanguageSpecificRegexes.computeIfAbsent(key, k -> new ArrayList<>()).add(regex);
+
+          hiddenLanguageSpecificRegexes.computeIfAbsent(key, k -> new ArrayList<>())
+              .add(Pattern.compile(regex, Pattern.CASE_INSENSITIVE));
         }
 
         continue;
@@ -57,13 +60,26 @@ public class CourseHiddenElements {
     return new CourseHiddenElements(hiddenIDs, hiddenRegexes, hiddenLanguageSpecificRegexes);
   }
 
+  public boolean shouldHideObject(long objectId, @NotNull String objectName, @Nullable String currentLanguage) {
+    if (hiddenIDs.contains(objectId)) {
+      return true;
+    }
+
+    if (hiddenRegexes.stream().anyMatch(r -> r.matcher(objectName).find())) {
+      return true;
+    }
+
+    return currentLanguage != null && hiddenLanguageSpecificRegexes.getOrDefault(currentLanguage, new ArrayList<>())
+        .stream().anyMatch(r -> r.matcher(objectName).find());
+  }
+
   public CourseHiddenElements() {
     this(null, null, null);
   }
 
-  public CourseHiddenElements(@Nullable List<Integer> hiddenIDs,
-                              @Nullable List<String> hiddenRegexes,
-                              @Nullable Map<String, List<String>> hiddenLanguageSpecificRegexes) {
+  public CourseHiddenElements(@Nullable List<Long> hiddenIDs,
+                              @Nullable List<Pattern> hiddenRegexes,
+                              @Nullable Map<String, List<Pattern>> hiddenLanguageSpecificRegexes) {
     if (hiddenIDs != null) {
       this.hiddenIDs.addAll(hiddenIDs);
     }

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
@@ -20,6 +20,7 @@ import fi.aalto.cs.apluscourses.presentation.filter.Options;
 import fi.aalto.cs.apluscourses.ui.InstallerDialogs;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
 import fi.aalto.cs.apluscourses.utils.CollectionUtil;
+import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -78,7 +79,9 @@ class InstallModuleActionTest {
         // tutorials
         Collections.emptyMap(),
         // pluginDependencies
-        Collections.emptyList());
+        Collections.emptyList(),
+        // hiddenElements
+        new CourseHiddenElements());
     mainViewModel.courseViewModel.set(new CourseViewModel(course, Options.EMPTY));
 
     installer = mock(ComponentInstaller.class);

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -3,6 +3,7 @@ package fi.aalto.cs.apluscourses.model;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
+import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.Version;
 import java.io.StringReader;
 import java.net.MalformedURLException;
@@ -54,7 +55,8 @@ class CourseTest {
         replAdditionalArguments,
         BuildInfo.INSTANCE.courseVersion,
         Collections.emptyMap(),
-        Collections.emptyList());
+        Collections.emptyList(),
+        new CourseHiddenElements());
     Assertions.assertEquals("13", course.getId(),
         "The ID of the course should be the same as that given to the constructor");
     Assertions.assertEquals("Tester Course", course.getName(),
@@ -119,7 +121,10 @@ class CourseTest {
         BuildInfo.INSTANCE.courseVersion,
         // tutorials
         Collections.emptyMap(),
-        Collections.emptyList());
+        // pluginDependencies
+        Collections.emptyList(),
+        // hiddenElements
+        new CourseHiddenElements());
     Assertions.assertSame(module2, course.getComponent("Awesome Module"),
         "Course#getModule should return the correct module");
   }
@@ -160,7 +165,10 @@ class CourseTest {
         BuildInfo.INSTANCE.courseVersion,
         // tutorials
         Collections.emptyMap(),
-        Collections.emptyList());
+        // pluginDependencies
+        Collections.emptyList(),
+        // hiddenElements
+        new CourseHiddenElements());
     List<Component> autoInstalls = course.getAutoInstallComponents();
     Assertions.assertEquals(2, autoInstalls.size(), "The course has the correct auto-install components");
     Assertions.assertEquals(moduleName, autoInstalls.get(0).getName());

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -5,6 +5,7 @@ import fi.aalto.cs.apluscourses.intellij.model.CommonLibraryProvider;
 import fi.aalto.cs.apluscourses.intellij.model.IntelliJCourse;
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
+import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import fi.aalto.cs.apluscourses.utils.Version;
 import fi.aalto.cs.apluscourses.utils.cache.CachePreference;
@@ -155,11 +156,11 @@ public class ModelExtensions {
                       @NotNull String replAdditionalArguments,
                       @NotNull Version courseVersion,
                       @NotNull Map<Long, Tutorial> tutorials,
-                      @NotNull List<PluginDependency> pluginDependencies) {
+                      @NotNull List<PluginDependency> pluginDependencies,
+                      @NotNull CourseHiddenElements hiddenElements) {
       super(id, name, aplusUrl, languages, modules, libraries, exerciseModules, resourceUrls, vmOptions,
-          optionalCategories, autoInstallComponentNames, replInitialCommands,
-          replAdditionalArguments, courseVersion, tutorials, pluginDependencies, null,
-          "default");
+          optionalCategories, autoInstallComponentNames, replInitialCommands, replAdditionalArguments,
+          courseVersion, tutorials, pluginDependencies, hiddenElements, null, "default");
       exerciseDataSource = new TestExerciseDataSource();
     }
 
@@ -204,7 +205,10 @@ public class ModelExtensions {
           // tutorials
           Collections.emptyMap(),
           // pluginDependencies
-          Collections.emptyList(), null, "default");
+          Collections.emptyList(),
+          // hiddenElements
+          new CourseHiddenElements(),
+          null, "default");
       this.exerciseDataSource = exerciseDataSource;
     }
 
@@ -263,6 +267,8 @@ public class ModelExtensions {
           Collections.emptyMap(),
           // pluginDependencies
           Collections.emptyList(),
+          // hiddenElements
+          new CourseHiddenElements(),
           null,
           null,
           0);
@@ -445,6 +451,7 @@ public class ModelExtensions {
                                @NotNull Version courseVersion,
                                @NotNull Map<Long, Tutorial> tutorials,
                                @NotNull List<PluginDependency> pluginDependencies,
+                               @NotNull CourseHiddenElements hiddenElements,
                                @Nullable String feedbackParser,
                                @Nullable String newsParser,
                                long courseLastModified) {
@@ -464,7 +471,8 @@ public class ModelExtensions {
           replAdditionalArguments,
           courseVersion,
           tutorials,
-          pluginDependencies
+          pluginDependencies,
+          hiddenElements
       );
     }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.ModelExtensions;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
+import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.observable.ValidationError;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
@@ -41,7 +42,9 @@ class CourseProjectViewModelTest {
       // tutorials
       Collections.emptyMap(),
       // pluginDependencies
-      Collections.emptyList()
+      Collections.emptyList(),
+      // hiddenElements
+      new CourseHiddenElements()
   );
 
   @Test


### PR DESCRIPTION
# Description of the PR
Closes #973
In the course configuration file, it is now possible to create a `hiddenElements` array to hide exercises and exercise groups based on ID or regex.

Example:
```
"hiddenElements": [
    {
        "byId": 1234
    },
    {
        "byRegex": "^[a-z]{4}$"
    },
    {
        "byRegex": {
            "fi": "palautekyselyn tulokset",
            "en": "course feedback survey"
        }
    }
]
```

Will hide:
- Exercise (or group) ID 1234
- All 4-letter exercise names
- All exercises containing "palautekyselyn tulokset" (if Finnish was chosen) or "course feedback survey" (if English was chosen)