### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 1.8
+          java-version: 17
 
       # The checkout action by default fetches the event that triggered the workflow, which in this case is the
       # pre-release tag.

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Setup A+ LMS locally
         run: chmod +x start_local_a+_env.sh && ./start_local_a+_env.sh
       - name: Build & Analyze

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
       - name: Build & Analyze
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       # The checkout action by default fetches the event that triggered the workflow, which in this case is the
       # pre-release tag.

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'scala'
     id 'checkstyle'
     id 'com.github.alisiikh.scalastyle' version '3.5.0'
-    id 'org.jetbrains.intellij' version '1.5.2'
+    id 'org.jetbrains.intellij' version '1.13.3'
     id 'org.sonarqube' version '4.0.0.2929'
     id 'jacoco'
 }
@@ -23,7 +23,10 @@ repositories {
 
 dependencies {
     implementation group: 'net.lingala.zip4j', name: 'zip4j', version: '2.11.5'
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.7.2")
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.9.3'
     test.useJUnitPlatform()
     compileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.13.10'
     implementation group: 'org.json', name: 'json', version: '20230227'
@@ -38,9 +41,9 @@ dependencies {
 
 intellij {
     // this is the version of the IntelliJ IDEA API (SDK) used to build the plugin
-    version = '222.4345.14'
+    version = '231.9011.34'
     updateSinceUntilBuild = false
-    plugins = ['java', 'org.intellij.scala:2022.1.13']
+    plugins = ['java', 'org.intellij.scala:2023.1.18']
 }
 
 patchPluginXml {

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ def courseVersion = '1.0'
 group 'fi.aalto.cs'
 version pluginVersion
 
-sourceCompatibility = 11
+sourceCompatibility = 17
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.7.2")
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.9.3'
     test.useJUnitPlatform()
     compileOnly group: 'org.scala-lang', name: 'scala-library', version: '2.13.10'
     implementation group: 'org.json', name: 'json', version: '20230227'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
             url="https://research.cs.aalto.fi/LeTech/">LeTech Group at Aalto University
     </vendor>
     <!--  this is the range of supported IntelliJ IDEA version the plugin can be used with  -->
-    <idea-version since-build="231.*"/>
+    <idea-version since-build="231.8109.175"/>
 
     <description><![CDATA[
     This plugin supports the educational use of IntelliJ IDEA (and its Scala plugin) in programming

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -5,7 +5,7 @@
             url="https://research.cs.aalto.fi/LeTech/">LeTech Group at Aalto University
     </vendor>
     <!--  this is the range of supported IntelliJ IDEA version the plugin can be used with  -->
-    <idea-version since-build="222.2680.4"/>
+    <idea-version since-build="231.*"/>
 
     <description><![CDATA[
     This plugin supports the educational use of IntelliJ IDEA (and its Scala plugin) in programming

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -1,6 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions
 
-import com.intellij.execution.configurations.{ConfigurationFactory, JavaCommandLineState, RunProfileState}
+import com.intellij.execution.configurations.{ConfigurationFactory, JavaCommandLineState, ModuleBasedConfiguration, RunConfigurationModule, RunProfileState}
 import com.intellij.execution.filters.TextConsoleBuilderImpl
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.ConsoleView
@@ -105,6 +105,8 @@ class ReplAction extends RunConsoleAction {
 
         state
       }
+
+      override def clone(): ModuleBasedConfiguration[_ <: RunConfigurationModule, _] = super.clone()
 
       private class MyBuilder(module: Module) extends TextConsoleBuilderImpl(module.getProject) {
         override def createConsole(): ConsoleView = new Repl(module)

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -1,6 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions
 
-import com.intellij.execution.configurations.{ConfigurationFactory, JavaCommandLineState, RunProfileState}
+import com.intellij.execution.configurations._
 import com.intellij.execution.filters.TextConsoleBuilderImpl
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.ConsoleView
@@ -87,6 +87,7 @@ class ReplAction extends RunConsoleAction {
 
     override def getId: String = getText("ui.repl.console.scala.repl.extended")
 
+    // scalastyle:off no.clone
     private class ReplConfiguration(project: Project,
                                     configurationFactory: ConfigurationFactory,
                                     name: String)
@@ -106,12 +107,14 @@ class ReplAction extends RunConsoleAction {
         state
       }
 
+      override def clone(): ModuleBasedConfiguration[_ <: RunConfigurationModule, _] = super.clone()
+
       private class MyBuilder(module: Module) extends TextConsoleBuilderImpl(module.getProject) {
         override def createConsole(): ConsoleView = new Repl(module)
       }
 
     }
-
+    // scalastyle:on no.clone
   }
 
   def getDefaultModule(@NotNull project: Project): Option[Module] = {

--- a/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
+++ b/src/main/scala/fi/aalto/cs/apluscourses/intellij/actions/ReplAction.scala
@@ -1,6 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions
 
-import com.intellij.execution.configurations.{ConfigurationFactory, JavaCommandLineState, ModuleBasedConfiguration, RunConfigurationModule, RunProfileState}
+import com.intellij.execution.configurations.{ConfigurationFactory, JavaCommandLineState, RunProfileState}
 import com.intellij.execution.filters.TextConsoleBuilderImpl
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.execution.ui.ConsoleView
@@ -13,7 +13,7 @@ import com.intellij.openapi.util.io.FileUtilRt.toSystemIndependentName
 import fi.aalto.cs.apluscourses.intellij.Repl
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings
 import fi.aalto.cs.apluscourses.intellij.services.PluginSettings.MODULE_REPL_INITIAL_COMMANDS_FILE_NAME
-import fi.aalto.cs.apluscourses.intellij.utils.{ModuleUtils, ReplChangesObserver}
+import fi.aalto.cs.apluscourses.intellij.utils.ModuleUtils
 import fi.aalto.cs.apluscourses.presentation.ReplConfigurationFormModel
 import fi.aalto.cs.apluscourses.ui.repl.{ReplConfigurationDialog, ReplConfigurationForm}
 import fi.aalto.cs.apluscourses.utils.PluginResourceBundle.{getAndReplaceText, getText}
@@ -105,8 +105,6 @@ class ReplAction extends RunConsoleAction {
 
         state
       }
-
-      override def clone(): ModuleBasedConfiguration[_ <: RunConfigurationModule, _] = super.clone()
 
       private class MyBuilder(module: Module) extends TextConsoleBuilderImpl(module.getProject) {
         override def createConsole(): ConsoleView = new Repl(module)

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManagerTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/utils/CourseFileManagerTest.java
@@ -80,7 +80,7 @@ class CourseFileManagerTest {
     var notifier = mock(Notifier.class);
 
     ModuleManager moduleManager = mock(ModuleManager.class);
-    when(project.getComponent(ModuleManager.class)).thenReturn(moduleManager);
+    when(project.getService(ModuleManager.class)).thenReturn(moduleManager);
     when(moduleManager.getModules()).thenReturn(new com.intellij.openapi.module.Module[0]);
     manager = new CourseFileManager(project, notifier);
   }


### PR DESCRIPTION
# Description of the PR
- Updated the `runIde` to finally use IntelliJ 2023.1
- The above required updating Gradle to 7.6
- The above required updating Java to version 17

Explanation of the changes:
- GitHub Actions had to be updated to use Java 17.
- `sourceCompatibility` change bumps the source language version to Java 17.
- The additional JUnit entries are required because the newest version of Gradle attempts to fetch JUnit's dependencies in a different way, which caused issues.
- The change to Scala code was needed because a compilation error (which I frankly do not understand) occurred.

As far as my testing goes, this also fixes #1011.