### PR TITLE
Update import path in Scala plugin extension

### DIFF
--- a/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ConsoleExecuteAction.scala
+++ b/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ConsoleExecuteAction.scala
@@ -14,7 +14,7 @@ import com.intellij.openapi.util.TextRange
 import fi.aalto.cs.apluscourses.intellij.Repl
 import org.jetbrains.plugins.scala.console.ScalaConsoleInfo
 import org.jetbrains.plugins.scala.console.actions.ScalaConsoleExecuteAction
-import org.jetbrains.plugins.scala.inWriteAction
+import org.jetbrains.plugins.scala.extensions.inWriteAction
 
 class ConsoleExecuteAction extends ScalaConsoleExecuteAction {
   // We achieve proper multiline support by surrounding the REPL commands by special


### PR DESCRIPTION
# Description of the PR
Fixes #1023

The commit by JetBrains https://github.com/JetBrains/intellij-scala/commit/052c2cf18356a3cdeba92f4e248a9873afde7b73 removed duplicated `inWriteAction` methods, therefore we have to make the same change to our file as well