### PR TITLE
Data Structures & Algorithms features

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ dependencies {
 
 intellij {
     // this is the version of the IntelliJ IDEA API (SDK) used to build the plugin
-    version = '231.9011.34'
+    version = '232.8660.185'
     updateSinceUntilBuild = false
-    plugins = ['java', 'org.intellij.scala:2023.1.18']
+    plugins = ['java', 'org.intellij.scala:2023.2.17']
 }
 
 patchPluginXml {

--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ dependencies {
 
 intellij {
     // this is the version of the IntelliJ IDEA API (SDK) used to build the plugin
-    version = '232.8660.185'
+    version = '231.9011.34'
     updateSinceUntilBuild = false
-    plugins = ['java', 'org.intellij.scala:2023.2.17']
+    plugins = ['java', 'org.intellij.scala:2023.1.18']
 }
 
 patchPluginXml {

--- a/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/APlusExerciseDataSource.java
@@ -224,7 +224,7 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
   public User getUser(@NotNull Authentication authentication) throws IOException {
     String url = apiUrl + USERS + "/" + ME + "/";
     JSONObject response = client.fetch(url, authentication);
-    return new User(authentication, parser.parseUserName(response));
+    return parser.parseUser(authentication, response);
   }
 
   @Override
@@ -403,10 +403,14 @@ public class APlusExerciseDataSource implements ExerciseDataSource {
     }
 
     @Override
-    public String parseUserName(@NotNull JSONObject object) {
+    public User parseUser(@NotNull Authentication authentication,
+                          @NotNull JSONObject object) {
       var fullName = object.optString("full_name");
       var username = object.optString("username");
-      return fullName.equals("") ? username : fullName;
+      var studentId = object.optString("student_id");
+      var id = object.optInt("id");
+
+      return new User(authentication, fullName.equals("") ? username : fullName, studentId, id);
     }
 
     @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/dal/Parser.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/dal/Parser.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.dal;
 
+import fi.aalto.cs.apluscourses.model.Authentication;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.Exercise;
 import fi.aalto.cs.apluscourses.model.Group;
@@ -7,6 +8,7 @@ import fi.aalto.cs.apluscourses.model.Points;
 import fi.aalto.cs.apluscourses.model.SubmissionInfo;
 import fi.aalto.cs.apluscourses.model.SubmissionResult;
 import fi.aalto.cs.apluscourses.model.Tutorial;
+import fi.aalto.cs.apluscourses.model.User;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,7 +44,8 @@ public interface Parser {
                                          @NotNull Exercise exercise,
                                          @NotNull Course course);
 
-  String parseUserName(@NotNull JSONObject object);
+  User parseUser(@NotNull Authentication authentication,
+                 @NotNull JSONObject jsonObject);
 
   ZonedDateTime parseEndingTime(@NotNull JSONObject object);
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -86,7 +86,8 @@ public class CourseProjectAction extends AnAction {
 
   private final ExecutorService executor;
 
-  private static final String COURSE_LIST_URL =
+  // TODO: change this back
+  public static String COURSE_LIST_URL =
       "https://version.aalto.fi/gitlab/aplus-courses/course-config-urls/-/raw/main/courses.yaml";
 
   private static final List<CourseItemViewModel> FALLBACK_COURSES = List.of(
@@ -163,6 +164,13 @@ public class CourseProjectAction extends AnAction {
 
     if (project == null) {
       return;
+    }
+
+    // TODO: remove this debugging helper
+    if (e.getInputEvent().isControlDown()) {
+      COURSE_LIST_URL = "http://192.168.177.11:8989/courses.yaml";
+    } else {
+      COURSE_LIST_URL = "https://version.aalto.fi/gitlab/aplus-courses/course-config-urls/-/raw/main/courses.yaml";
     }
 
     URL courseUrl = tryGetCourseUrl(project);
@@ -361,7 +369,7 @@ public class CourseProjectAction extends AnAction {
 
   private void startAutoInstalls(@NotNull Course course, @NotNull Project project) {
     ComponentInstaller.Dialogs installerDialogs = installerDialogsFactory.getDialogs(project);
-    ComponentInstaller installer = installerFactory.getInstallerFor(course, installerDialogs);
+    ComponentInstaller installer = installerFactory.getInstallerFor(course, installerDialogs, course.getCallbacks());
     installer.install(course.getAutoInstallComponents());
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -86,11 +86,14 @@ public class CourseProjectAction extends AnAction {
 
   private final ExecutorService executor;
 
-  // TODO: change this back
-  public static String COURSE_LIST_URL =
+  private static final String COURSE_LIST_URL =
       "https://version.aalto.fi/gitlab/aplus-courses/course-config-urls/-/raw/main/courses.yaml";
 
   private static final List<CourseItemViewModel> FALLBACK_COURSES = List.of(
+      new CourseItemViewModel("CS-A1141 Tietorakenteet ja algoritmit Y", "Fall 2023",
+          "https://gitmanager.cs.aalto.fi/static/CS-A1141_2023Autumn/_static/apluscourses/a1141_course_config.json"),
+      new CourseItemViewModel("CS-A1143 Data Structures and Algorithms Y", "Fall 2023",
+          "https://gitmanager.cs.aalto.fi/static/CS-A1143_2023Autumn/_static/apluscourses/a1143_course_config.json"),
       new CourseItemViewModel("Ohjelmointistudio 2 / Programming Studio A", "Spring 2023",
           "https://gitmanager.cs.aalto.fi/static/studios-spring-2023/modules/s2_course_config.json"),
       new CourseItemViewModel("O1", "Fall 2022",

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -166,13 +166,6 @@ public class CourseProjectAction extends AnAction {
       return;
     }
 
-    // TODO: remove this debugging helper
-    if (e.getInputEvent().isControlDown()) {
-      COURSE_LIST_URL = "http://192.168.177.11:8989/courses.yaml";
-    } else {
-      COURSE_LIST_URL = "https://version.aalto.fi/gitlab/aplus-courses/course-config-urls/-/raw/main/courses.yaml";
-    }
-
     URL courseUrl = tryGetCourseUrl(project);
     if (courseUrl == null) {
       return;

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleAction.java
@@ -74,7 +74,8 @@ public class InstallModuleAction extends DumbAwareAction {
           .collect(Collectors.toList());
       logger.info("Downloading modules: {}", modules);
       Course course = courseViewModel.getModel();
-      componentInstallerFactory.getInstallerFor(course, dialogsFactory.getDialogs(e.getProject()))
+      componentInstallerFactory.getInstallerFor(course,
+              dialogsFactory.getDialogs(e.getProject()), course.getCallbacks())
           .installAsync(modules, () -> downloadDone(course));
     }
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/activities/InitializationActivity.java
@@ -109,6 +109,9 @@ public class InitializationActivity implements Background {
 
       return;
     }
+
+    cardVm.setModuleButtonRequiresLogin(course.requiresLoginForModules());
+
     var progress = progressViewModel.start(3, getText("ui.ProgressBarView.loading"), false);
     progress.increment();
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/CourseProject.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/CourseProject.java
@@ -151,6 +151,20 @@ public class CourseProject implements ExercisesLazyLoader {
   }
 
   @NotNull
+  public String getUserStudentId() {
+    return Optional.ofNullable(user.get()).map(User::getStudentId).orElse("");
+  }
+
+  public int getUserAPlusId() {
+    return Optional.ofNullable(user.get()).map(User::getId).orElse(0);
+  }
+
+  @Nullable
+  public User getUser() {
+    return user.get();
+  }
+
+  @NotNull
   public Course getCourse() {
     return course;
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -19,6 +19,7 @@ import fi.aalto.cs.apluscourses.model.ExerciseDataSource;
 import fi.aalto.cs.apluscourses.model.Library;
 import fi.aalto.cs.apluscourses.model.Module;
 import fi.aalto.cs.apluscourses.model.Tutorial;
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import fi.aalto.cs.apluscourses.utils.Version;
@@ -68,6 +69,7 @@ public class IntelliJCourse extends Course {
                         @NotNull Map<Long, Tutorial> tutorials,
                         @NotNull List<PluginDependency> pluginDependencies,
                         @NotNull CourseHiddenElements hiddenElements,
+                        @NotNull Callbacks callbacks,
                         @Nullable String feedbackParser,
                         @Nullable String newsParser,
                         long courseLastModified) {
@@ -89,6 +91,7 @@ public class IntelliJCourse extends Course {
         tutorials,
         pluginDependencies,
         hiddenElements,
+        callbacks,
         feedbackParser,
         newsParser
     );

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJCourse.java
@@ -70,6 +70,7 @@ public class IntelliJCourse extends Course {
                         @NotNull List<PluginDependency> pluginDependencies,
                         @NotNull CourseHiddenElements hiddenElements,
                         @NotNull Callbacks callbacks,
+                        boolean requireAuthenticationForModules,
                         @Nullable String feedbackParser,
                         @Nullable String newsParser,
                         long courseLastModified) {
@@ -92,6 +93,7 @@ public class IntelliJCourse extends Course {
         pluginDependencies,
         hiddenElements,
         callbacks,
+        requireAuthenticationForModules,
         feedbackParser,
         newsParser
     );

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -9,6 +9,7 @@ import fi.aalto.cs.apluscourses.model.ModelFactory;
 import fi.aalto.cs.apluscourses.model.Module;
 import fi.aalto.cs.apluscourses.model.ModuleMetadata;
 import fi.aalto.cs.apluscourses.model.Tutorial;
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import fi.aalto.cs.apluscourses.utils.Version;
@@ -57,6 +58,7 @@ public class IntelliJModelFactory implements ModelFactory {
                              @NotNull Map<Long, Tutorial> tutorials,
                              @NotNull List<PluginDependency> pluginDependencies,
                              @NotNull CourseHiddenElements hiddenElements,
+                             @NotNull Callbacks callbacks,
                              @Nullable String feedbackParser,
                              @Nullable String newsParser,
                              long courseLastModified) {
@@ -65,7 +67,7 @@ public class IntelliJModelFactory implements ModelFactory {
         new IntelliJCourse(id, name, aplusUrl, languages, modules, libraries, exerciseModules,
             resourceUrls, vmOptions, optionalCategories, autoInstallComponentNames, replInitialCommands,
             replAdditionalArguments, courseVersion, project, new CommonLibraryProvider(project), tutorials,
-            pluginDependencies, hiddenElements, feedbackParser, newsParser, courseLastModified);
+            pluginDependencies, hiddenElements, callbacks, feedbackParser, newsParser, courseLastModified);
 
     Component.InitializationCallback componentInitializationCallback =
         component -> registerComponentToCourse(component, course);

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModelFactory.java
@@ -59,6 +59,7 @@ public class IntelliJModelFactory implements ModelFactory {
                              @NotNull List<PluginDependency> pluginDependencies,
                              @NotNull CourseHiddenElements hiddenElements,
                              @NotNull Callbacks callbacks,
+                             boolean requireAuthenticationForModules,
                              @Nullable String feedbackParser,
                              @Nullable String newsParser,
                              long courseLastModified) {
@@ -67,7 +68,8 @@ public class IntelliJModelFactory implements ModelFactory {
         new IntelliJCourse(id, name, aplusUrl, languages, modules, libraries, exerciseModules,
             resourceUrls, vmOptions, optionalCategories, autoInstallComponentNames, replInitialCommands,
             replAdditionalArguments, courseVersion, project, new CommonLibraryProvider(project), tutorials,
-            pluginDependencies, hiddenElements, callbacks, feedbackParser, newsParser, courseLastModified);
+            pluginDependencies, hiddenElements, callbacks, requireAuthenticationForModules,
+            feedbackParser, newsParser, courseLastModified);
 
     Component.InitializationCallback componentInitializationCallback =
         component -> registerComponentToCourse(component, course);

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/model/IntelliJModule.java
@@ -9,6 +9,7 @@ import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.intellij.utils.ListDependenciesPolicy;
 import fi.aalto.cs.apluscourses.intellij.utils.VfsUtil;
 import fi.aalto.cs.apluscourses.model.ComponentLoadException;
+import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.Module;
 import fi.aalto.cs.apluscourses.utils.Version;
 import fi.aalto.cs.apluscourses.utils.content.RemoteZippedDir;
@@ -72,6 +73,11 @@ class IntelliJModule
         .copyTo(getFullPath(), project.getProject());
     if (!getFullPath().resolve(getOriginalName() + ".iml").toFile().renameTo(getImlFile())) {
       throw new IOException("Could not rename iml file.");
+    }
+
+    CourseProject courseProject = PluginSettings.getInstance().getCourseProject(project.getProject());
+    if (courseProject != null) {
+      courseProject.getCourse().getCallbacks().invokePostDownloadModuleCallbacks(project.getProject(), this);
     }
   }
 

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/SubmissionDownloader.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/utils/SubmissionDownloader.java
@@ -143,7 +143,7 @@ public class SubmissionDownloader {
 
     var moduleVf = virtualFileFinder.findFile(moduleCopy.getFullPath().toFile());
 
-    componentInstallerFactory.getInstallerFor(course, dialogsFactory.getDialogs(project))
+    componentInstallerFactory.getInstallerFor(course, dialogsFactory.getDialogs(project), course.getCallbacks())
         .installAsync(List.of(moduleCopy),
             () -> fileRefresher.refreshPath(moduleVf,
                 () -> downloadFiles(project,

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ComponentInstaller.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ComponentInstaller.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.model;
 
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import java.util.List;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -18,7 +19,8 @@ public interface ComponentInstaller {
   interface Factory {
     @NotNull
     ComponentInstaller getInstallerFor(@NotNull ComponentSource componentSource,
-                                       @NotNull Dialogs dialogs);
+                                       @NotNull Dialogs dialogs,
+                                       @NotNull Callbacks callbacks);
   }
 
   interface Dialogs {

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ComponentInstallerImpl.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ComponentInstallerImpl.java
@@ -1,6 +1,7 @@
 package fi.aalto.cs.apluscourses.model;
 
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.async.TaskManager;
 import java.io.IOException;
 import java.util.List;
@@ -13,9 +14,10 @@ public class ComponentInstallerImpl<T> implements ComponentInstaller {
 
   private static final Logger logger = APlusLogger.logger;
 
-  private final ComponentSource componentSource;
-  private final TaskManager<T> taskManager;
-  private final Dialogs dialogs;
+  private final @NotNull ComponentSource componentSource;
+  private final @NotNull TaskManager<T> taskManager;
+  private final @NotNull Dialogs dialogs;
+  private final @NotNull Callbacks callbacks;
 
   /**
    * Constructor.
@@ -26,10 +28,12 @@ public class ComponentInstallerImpl<T> implements ComponentInstaller {
    */
   public ComponentInstallerImpl(@NotNull ComponentSource componentSource,
                                 @NotNull TaskManager<T> taskManager,
-                                @NotNull Dialogs dialogs) {
+                                @NotNull Dialogs dialogs,
+                                @NotNull Callbacks callbacks) {
     this.componentSource = componentSource;
     this.taskManager = taskManager;
     this.dialogs = dialogs;
+    this.callbacks = callbacks;
   }
 
   protected T waitUntilLoadedAsync(Component component) {
@@ -174,8 +178,9 @@ public class ComponentInstallerImpl<T> implements ComponentInstaller {
     @Override
     @NotNull
     public ComponentInstaller getInstallerFor(@NotNull ComponentSource componentSource,
-                                              @NotNull Dialogs dialogs) {
-      return new ComponentInstallerImpl<>(componentSource, taskManager, dialogs);
+                                              @NotNull Dialogs dialogs,
+                                              @NotNull Callbacks callbacks) {
+      return new ComponentInstallerImpl<>(componentSource, taskManager, dialogs, callbacks);
     }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -816,7 +816,9 @@ public abstract class Course implements ComponentSource {
     return callbacks;
   }
 
-  public boolean requiresLoginForModules() { return requireAuthenticationForModules; }
+  public boolean requiresLoginForModules() {
+    return requireAuthenticationForModules;
+  }
 
   @NotNull
   public abstract ExerciseDataSource getExerciseDataSource();

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -101,6 +101,8 @@ public abstract class Course implements ComponentSource {
   @Nullable
   private final String newsParser;
 
+  private boolean requireAuthenticationForModules;
+
   /**
    * Constructs a course with the given parameters.
    *
@@ -129,6 +131,7 @@ public abstract class Course implements ComponentSource {
                    @NotNull List<PluginDependency> pluginDependencies,
                    @NotNull CourseHiddenElements hiddenElements,
                    @NotNull Callbacks callbacks,
+                   boolean requireAuthenticationForModules,
                    @Nullable String feedbackParser,
                    @Nullable String newsParser) {
     this.id = id;
@@ -146,6 +149,7 @@ public abstract class Course implements ComponentSource {
     this.pluginDependencies = pluginDependencies;
     this.hiddenElements = hiddenElements;
     this.callbacks = callbacks;
+    this.requireAuthenticationForModules = requireAuthenticationForModules;
     this.feedbackParser = feedbackParser;
     this.newsParser = newsParser;
     this.components = Stream.concat(modules.stream(), libraries.stream())
@@ -212,6 +216,7 @@ public abstract class Course implements ComponentSource {
     List<PluginDependency> pluginDependencies = getCoursePluginDependencies(jsonObject, sourcePath);
     CourseHiddenElements hiddenElements = getCourseHiddenElements(jsonObject, sourcePath);
     Callbacks callbacks = getCourseCallbacks(jsonObject, sourcePath);
+    boolean requireAuthenticationForModules = jsonObject.optBoolean("requireAuthenticationForModules", false);
     String feedbackParser = jsonObject.optString("feedbackParser", null);
     String newsParser = jsonObject.optString("newsParser", null);
     long courseLastModified = jsonObject.optLong("courseLastModified");
@@ -234,6 +239,7 @@ public abstract class Course implements ComponentSource {
         pluginDependencies,
         hiddenElements,
         callbacks,
+        requireAuthenticationForModules,
         feedbackParser,
         newsParser,
         courseLastModified
@@ -809,6 +815,8 @@ public abstract class Course implements ComponentSource {
   public Callbacks getCallbacks() {
     return callbacks;
   }
+
+  public boolean requiresLoginForModules() { return requireAuthenticationForModules; }
 
   @NotNull
   public abstract ExerciseDataSource getExerciseDataSource();

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
@@ -31,6 +31,7 @@ public interface ModelFactory {
                       @NotNull List<PluginDependency> pluginDependencies,
                       @NotNull CourseHiddenElements hiddenElements,
                       @NotNull Callbacks callbacks,
+                      boolean requireAuthenticationForModules,
                       @Nullable String feedbackParser,
                       @NotNull String newsParser,
                       long courseLastModified);

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ModelFactory.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.model;
 
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import fi.aalto.cs.apluscourses.utils.Version;
@@ -29,6 +30,7 @@ public interface ModelFactory {
                       @NotNull Map<Long, Tutorial> tutorials,
                       @NotNull List<PluginDependency> pluginDependencies,
                       @NotNull CourseHiddenElements hiddenElements,
+                      @NotNull Callbacks callbacks,
                       @Nullable String feedbackParser,
                       @NotNull String newsParser,
                       long courseLastModified);

--- a/src/main/java/fi/aalto/cs/apluscourses/model/User.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/User.java
@@ -9,13 +9,22 @@ public class User {
   @NotNull
   private final String userName;
 
+  @NotNull
+  private final String studentId;
+
+  private final int id;
+
   /**
    * A constructor.
    */
   public User(@NotNull Authentication authentication,
-              @NotNull String userName) {
+              @NotNull String userName,
+              @NotNull String studentId,
+              int id) {
     this.authentication = authentication;
     this.userName = userName;
+    this.studentId = studentId;
+    this.id = id;
   }
 
   @NotNull
@@ -26,5 +35,14 @@ public class User {
   @NotNull
   public String getUserName() {
     return userName;
+  }
+
+  @NotNull
+  public String getStudentId() {
+    return studentId;
+  }
+
+  public int getId() {
+    return id;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/ToolWindowCardViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/ToolWindowCardViewModel.java
@@ -70,5 +70,6 @@ public class ToolWindowCardViewModel {
 
   public void setModuleButtonRequiresLogin(boolean requiresLogin) {
     moduleButtonRequiresLogin = requiresLogin;
+    updated.trigger();
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/ToolWindowCardViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/ToolWindowCardViewModel.java
@@ -19,6 +19,8 @@ public class ToolWindowCardViewModel {
 
   private boolean isAPlusProject;
 
+  private boolean moduleButtonRequiresLogin;
+
   @NotNull
   private final AtomicBoolean isProjectReady = new AtomicBoolean(false);
 
@@ -62,20 +64,11 @@ public class ToolWindowCardViewModel {
     updated.trigger();
   }
 
-  /**
-   * Returns the name of the current card.
-   */
-  @NotNull
-  public String getCurrentCard() {
-    if (!isProjectReady()) {
-      return LOADING_CARD;
-    } else if (isNetworkError()) {
-      return ERROR_CARD;
-    } else if (!isAPlusProject()) {
-      return PROJECT_CARD;
-    } else if (isAuthenticated()) {
-      return MAIN_CARD;
-    }
-    return NO_TOKEN_CARD;
+  public boolean moduleButtonRequiresLogin() {
+    return moduleButtonRequiresLogin;
+  }
+
+  public void setModuleButtonRequiresLogin(boolean requiresLogin) {
+    moduleButtonRequiresLogin = requiresLogin;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectView.java
@@ -97,5 +97,8 @@ public class CourseProjectView extends OurDialogWrapper {
         APlusLocalizationUtil::languageCodeToName,
         null));
     languageComboBox.selectedItemBindable.bindToSource(viewModel.languageProperty);
+    if (languageComboBox.getItemCount() == 1) {
+      languageComboBox.setSelectedIndex(0);
+    }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/courseproject/CourseProjectView.java
@@ -97,6 +97,8 @@ public class CourseProjectView extends OurDialogWrapper {
         APlusLocalizationUtil::languageCodeToName,
         null));
     languageComboBox.selectedItemBindable.bindToSource(viewModel.languageProperty);
+
+    // If there is only one language available, select it by default.
     if (languageComboBox.getItemCount() == 1) {
       languageComboBox.setSelectedIndex(0);
     }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/toolwindowcards/NoTokenCard.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/toolwindowcards/NoTokenCard.java
@@ -18,7 +18,7 @@ public class NoTokenCard {
   /**
    * Constructor.
    */
-  public NoTokenCard(@NotNull Project project, boolean hideModulesButton) {
+  public NoTokenCard(@NotNull Project project) {
     setATokenButton.addActionListener(e -> {
       DataContext context = DataManager.getInstance().getDataContext(setATokenButton);
       ActionUtil.launch(APlusAuthenticationAction.ACTION_ID, context);
@@ -27,7 +27,10 @@ public class NoTokenCard {
       var modulesDialog = new ModulesDialog(project);
       modulesDialog.show();
     });
-    modulesButton.setVisible(!hideModulesButton);
+  }
+
+  public void setModulesButtonHidden(boolean isHidden) {
+    modulesButton.setVisible(!isHidden);
   }
 
   public JPanel getPanel() {

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/toolwindowcards/NoTokenCard.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/toolwindowcards/NoTokenCard.java
@@ -18,7 +18,7 @@ public class NoTokenCard {
   /**
    * Constructor.
    */
-  public NoTokenCard(@NotNull Project project) {
+  public NoTokenCard(@NotNull Project project, boolean hideModulesButton) {
     setATokenButton.addActionListener(e -> {
       DataContext context = DataManager.getInstance().getDataContext(setATokenButton);
       ActionUtil.launch(APlusAuthenticationAction.ACTION_ID, context);
@@ -27,6 +27,7 @@ public class NoTokenCard {
       var modulesDialog = new ModulesDialog(project);
       modulesDialog.show();
     });
+    modulesButton.setVisible(!hideModulesButton);
   }
 
   public JPanel getPanel() {

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/toolwindowcards/ToolWindowCardView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/toolwindowcards/ToolWindowCardView.java
@@ -21,6 +21,8 @@ public class ToolWindowCardView extends JPanel {
   private final Project project;
   @NotNull
   private final ToolWindowCardViewModel viewModel;
+  @NotNull
+  private final NoTokenCard noTokenCard;
 
   /**
    * Constructor.
@@ -38,9 +40,9 @@ public class ToolWindowCardView extends JPanel {
     this.add(toolWindowPanel);
     this.cl.addLayoutComponent(toolWindowPanel, MAIN_CARD);
 
-    var noTokenView = new NoTokenCard(project, viewModel.moduleButtonRequiresLogin());
-    this.add(noTokenView.getPanel());
-    this.cl.addLayoutComponent(noTokenView.getPanel(), NO_TOKEN_CARD);
+    noTokenCard = new NoTokenCard(project);
+    this.add(noTokenCard.getPanel());
+    this.cl.addLayoutComponent(noTokenCard.getPanel(), NO_TOKEN_CARD);
 
     var notAPlusProjectView = new NotAPlusProjectCard();
     this.add(notAPlusProjectView.getPanel());
@@ -71,6 +73,7 @@ public class ToolWindowCardView extends JPanel {
           } else if (viewModel.isAuthenticated()) {
             cl.show(this, MAIN_CARD);
           } else {
+            noTokenCard.setModulesButtonHidden(viewModel.moduleButtonRequiresLogin());
             cl.show(this, NO_TOKEN_CARD);
           }
         }, ModalityState.any()

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/toolwindowcards/ToolWindowCardView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/toolwindowcards/ToolWindowCardView.java
@@ -38,7 +38,7 @@ public class ToolWindowCardView extends JPanel {
     this.add(toolWindowPanel);
     this.cl.addLayoutComponent(toolWindowPanel, MAIN_CARD);
 
-    var noTokenView = new NoTokenCard(project);
+    var noTokenView = new NoTokenCard(project, viewModel.moduleButtonRequiresLogin());
     this.add(noTokenView.getPanel());
     this.cl.addLayoutComponent(noTokenView.getPanel(), NO_TOKEN_CARD);
 

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/Callbacks.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/Callbacks.java
@@ -46,6 +46,9 @@ public class Callbacks {
     postDownloadModuleCallbacks.forEach(callback -> callback.postDownloadModule(project, module));
   }
 
+  /**
+   * Constructs an instance of callbacks from the given JSON object.
+   */
   @NotNull
   public static Callbacks fromJsonObject(@NotNull JSONObject callbacksObject) {
     List<PostDownloadModuleCallback> postDownloadModuleCallbacks = new ArrayList<>();
@@ -55,13 +58,16 @@ public class Callbacks {
     return new Callbacks(postDownloadModuleCallbacks);
   }
 
-  public Callbacks() {
-    this(null);
-  }
-
-  public Callbacks(@Nullable List<PostDownloadModuleCallback> postDownloadModuleCallbacks) {
+  private Callbacks(@Nullable List<PostDownloadModuleCallback> postDownloadModuleCallbacks) {
     if (postDownloadModuleCallbacks != null) {
       this.postDownloadModuleCallbacks.addAll(postDownloadModuleCallbacks);
     }
+  }
+
+  /**
+   * Constructor without any callbacks.
+   */
+  public Callbacks() {
+    this(null);
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/Callbacks.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/Callbacks.java
@@ -1,0 +1,72 @@
+package fi.aalto.cs.apluscourses.utils;
+
+import com.intellij.openapi.project.Project;
+import fi.aalto.cs.apluscourses.model.Module;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class Callbacks {
+
+  @NotNull
+  private final List<Method> postDownloadModuleCallbacks = new ArrayList<>();
+
+  private static void addCallbacksFromArray(@Nullable JSONArray callbackArray,
+                                            @NotNull String methodName,
+                                            @NotNull List<Method> callbackList) throws ClassNotFoundException {
+    if (callbackArray == null) {
+      return;
+    }
+
+    for (int i = 0; i < callbackArray.length(); i++) {
+      String className = callbackArray.getString(i);
+
+      Class<?> callbackClass = Class.forName("fi.aalto.cs.apluscourses.utils.callbacks." + className);
+      Method method = Arrays.stream(callbackClass.getDeclaredMethods())
+          .filter(m -> m.getName().equals(methodName))
+          .findFirst()
+          .orElseThrow();
+
+      callbackList.add(method);
+    }
+  }
+
+  public void invokePostDownloadModuleCallbacks(@NotNull Project project, @NotNull Module module) {
+    postDownloadModuleCallbacks.forEach(method -> {
+      try {
+        method.invoke(null, project, module);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException(e);
+      }
+    });
+  }
+
+  @NotNull
+  public static Callbacks fromJsonObject(@NotNull JSONObject callbacksObject) {
+    List<Method> postDownloadModuleCallbacks = new ArrayList<>();
+
+    try {
+      addCallbacksFromArray(callbacksObject.optJSONArray("postDownloadModule"),
+          "postDownloadModule", postDownloadModuleCallbacks);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+
+    return new Callbacks(postDownloadModuleCallbacks);
+  }
+
+  public Callbacks() {
+    this(null);
+  }
+
+  public Callbacks(@Nullable List<Method> postDownloadModuleCallbacks) {
+    if (postDownloadModuleCallbacks != null) {
+      this.postDownloadModuleCallbacks.addAll(postDownloadModuleCallbacks);
+    }
+  }
+}

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
@@ -22,7 +22,8 @@ import org.slf4j.Logger;
 public class AddModuleWatermark {
 
   private static final String ENCODING_LINE = "# -*- coding: utf-8 -*-";
-  private static final String ENCODING_LINE_WITH_UNICODE = "#\u200b\u200c\u200b\u200b\u200b\u200b\u200c\u200c\u200b\u200c\u200b\u200c\u200c\u200b *-* coding: utf-8 *-*";
+  private static final String ENCODING_LINE_WITH_UNICODE =
+      "#\u200b\u200c\u200b\u200b\u200b\u200b\u200c\u200c\u200b\u200c\u200b\u200c\u200c\u200b *-* coding: utf-8 *-*";
 
   private AddModuleWatermark() {
 

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
@@ -21,8 +21,6 @@ import org.slf4j.Logger;
 
 public class AddModuleWatermark {
 
-  private static final Logger logger = APlusLogger.logger;
-
   private static final String ENCODING_LINE = "# -*- coding: utf-8 -*-";
   private static final String ENCODING_LINE_WITH_UNICODE = "#​‌​​​​‌‌​‌​‌‌​ *-* coding: utf-8 *-*";
 
@@ -63,6 +61,11 @@ public class AddModuleWatermark {
     }
   }
 
+  /**
+   * Adds a watermark to a freshly downloaded module. This is used in TRAKY courses.
+   * @param project The project
+   * @param module The currently extracted module
+   */
   public static void postDownloadModule(@NotNull Project project, @NotNull Module module) {
     final CourseProject courseProject = PluginSettings.getInstance().getCourseProject(project);
     final User user = courseProject != null ? courseProject.getUser() : null;

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
@@ -6,6 +6,7 @@ import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
 import fi.aalto.cs.apluscourses.model.Module;
 import fi.aalto.cs.apluscourses.model.User;
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
@@ -22,7 +22,7 @@ import org.slf4j.Logger;
 public class AddModuleWatermark {
 
   private static final String ENCODING_LINE = "# -*- coding: utf-8 -*-";
-  private static final String ENCODING_LINE_WITH_UNICODE = "#​‌​​​​‌‌​‌​‌‌​ *-* coding: utf-8 *-*";
+  private static final String ENCODING_LINE_WITH_UNICODE = "#\u200b\u200c\u200b\u200b\u200b\u200b\u200c\u200c\u200b\u200c\u200b\u200c\u200c\u200b *-* coding: utf-8 *-*";
 
   private AddModuleWatermark() {
 
@@ -30,8 +30,8 @@ public class AddModuleWatermark {
 
   private static String createWatermark(int userId) {
     return Integer.toBinaryString(userId)
-        .replace('1', '\u200B')
-        .replace('0', '\u200C');
+        .replace('1', '\u200b')
+        .replace('0', '\u200c');
   }
 
   private static void addWatermark(@NotNull Path path, @Nullable User user) throws IOException {

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
@@ -1,0 +1,86 @@
+package fi.aalto.cs.apluscourses.utils.callbacks;
+
+import com.intellij.openapi.project.Project;
+import fi.aalto.cs.apluscourses.intellij.model.CourseProject;
+import fi.aalto.cs.apluscourses.intellij.services.PluginSettings;
+import fi.aalto.cs.apluscourses.model.Module;
+import fi.aalto.cs.apluscourses.model.User;
+import fi.aalto.cs.apluscourses.utils.APlusLogger;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+
+public class AddModuleWatermark {
+
+  private static final Logger logger = APlusLogger.logger;
+
+  private static final String ENCODING_LINE = "# -*- coding: utf-8 -*-";
+  private static final String ENCODING_LINE_WITH_UNICODE = "#​‌​​​​‌‌​‌​‌‌​ *-* coding: utf-8 *-*";
+
+  private AddModuleWatermark() {
+
+  }
+
+  private static String createWatermark(int userId) {
+    return Integer.toBinaryString(userId)
+        .replace('1', '\u200B')
+        .replace('0', '\u200C');
+  }
+
+  private static void addWatermark(@NotNull Path path, @Nullable User user) throws IOException {
+    final int userId = user != null ? user.getId() : 0;
+    final String studentId = user != null ? user.getStudentId() : "---";
+    final String studentName = user != null ? user.getUserName() : "---";
+
+    final String watermark = createWatermark(userId);
+
+    try (Stream<String> lineStream = Files.lines(path)) {
+      var newLines = lineStream.map(line -> {
+        if (line.equals(ENCODING_LINE) || line.equals(ENCODING_LINE_WITH_UNICODE)) {
+          return "";
+        } else if (line.trim().startsWith("#")) {
+          return line.replaceFirst("#", "#" + watermark);
+        }
+        return line;
+      }).toList();
+
+      var newLinesMutable = new ArrayList<>(newLines);
+
+      newLinesMutable.add(0, ENCODING_LINE);
+      newLinesMutable.add(1, "# Nimi: " + studentName);
+      newLinesMutable.add(2, "# Opiskelijanumero: " + studentId);
+
+      Files.write(path, newLinesMutable);
+    }
+  }
+
+  public static void postDownloadModule(@NotNull Project project, @NotNull Module module) {
+    final CourseProject courseProject = PluginSettings.getInstance().getCourseProject(project);
+    final User user = courseProject != null ? courseProject.getUser() : null;
+
+    try {
+      try (Stream<Path> entries = Files.walk(module.getFullPath())) {
+        entries.forEach(path -> {
+          final File file = path.toFile();
+          if (file.isFile() && file.getName().toLowerCase().endsWith(".py")) {
+            try {
+              addWatermark(path, user);
+            } catch (IOException e) {
+              throw new UncheckedIOException(e);
+            }
+          }
+        });
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/src/main/resources/resources.properties
+++ b/src/main/resources/resources.properties
@@ -82,8 +82,8 @@ presentation.filter.selectAll=Select all
 presentation.filter.deselectAll=Deselect all
 presentation.userDropdown.logIn=Log in
 presentation.userDropdown.logOut=Log out
-presentation.userDropdown.notLoggedIn=Not Logged In
-presentation.userDropdown.loggedInAs=Logged In As {0}
+presentation.userDropdown.notLoggedIn=Not logged in
+presentation.userDropdown.loggedInAs=Logged in as {0}
 presentation.navbar.progress=Step {0}/{1}
 # UI
 ## REPL

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
@@ -19,6 +19,7 @@ import fi.aalto.cs.apluscourses.presentation.MainViewModel;
 import fi.aalto.cs.apluscourses.presentation.filter.Options;
 import fi.aalto.cs.apluscourses.ui.InstallerDialogs;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.CollectionUtil;
 import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import java.util.ArrayList;
@@ -81,7 +82,9 @@ class InstallModuleActionTest {
         // pluginDependencies
         Collections.emptyList(),
         // hiddenElements
-        new CourseHiddenElements());
+        new CourseHiddenElements(),
+        // callbacks
+        new Callbacks());
     mainViewModel.courseViewModel.set(new CourseViewModel(course, Options.EMPTY));
 
     installer = mock(ComponentInstaller.class);

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
@@ -84,7 +84,9 @@ class InstallModuleActionTest {
         // hiddenElements
         new CourseHiddenElements(),
         // callbacks
-        new Callbacks());
+        new Callbacks(),
+        // requireAuthenticationForModules
+        false);
     mainViewModel.courseViewModel.set(new CourseViewModel(course, Options.EMPTY));
 
     installer = mock(ComponentInstaller.class);

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleActionTest.java
@@ -95,7 +95,7 @@ class InstallModuleActionTest {
   @SuppressWarnings({"ConstantConditions"})
   @Test
   void testUpdate() {
-    InstallModuleAction action = new InstallModuleAction(p -> mainViewModel, (c, d) -> installer,
+    InstallModuleAction action = new InstallModuleAction(p -> mainViewModel, (c, d, e) -> installer,
         dialogsFactory);
 
     Presentation presentation = new Presentation();
@@ -120,7 +120,7 @@ class InstallModuleActionTest {
   @SuppressWarnings({"unchecked", "ConstantConditions"})
   @Test
   void testActionPerformed() {
-    InstallModuleAction action = new InstallModuleAction(p -> mainViewModel, (c, d) -> installer,
+    InstallModuleAction action = new InstallModuleAction(p -> mainViewModel, (c, d, e) -> installer,
         dialogsFactory);
 
     AnActionEvent e = mock(AnActionEvent.class);

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/UserActionGroupTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/UserActionGroupTest.java
@@ -48,10 +48,10 @@ class UserActionGroupTest {
   @Test
   void testUserActionGroup() {
     action.update(event);
-    Assertions.assertEquals("Not Logged In", event.getPresentation().getText());
+    Assertions.assertEquals("Not logged in", event.getPresentation().getText());
     var authentication = mock(Authentication.class);
     courseProject.setAuthentication(authentication);
     action.update(event);
-    Assertions.assertEquals("Logged In As test", event.getPresentation().getText());
+    Assertions.assertEquals("Logged in as test", event.getPresentation().getText());
   }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/UserNameActionTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/intellij/actions/UserNameActionTest.java
@@ -48,7 +48,7 @@ class UserNameActionTest {
   @Test
   void testUserNameAction() {
     action.update(event);
-    Assertions.assertEquals("Not Logged In", event.getPresentation().getText());
+    Assertions.assertEquals("Not logged in", event.getPresentation().getText());
     var authentication = mock(Authentication.class);
     courseProject.setAuthentication(authentication);
     action.update(event);

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ComponentInstallerTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ComponentInstallerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.async.SimpleAsyncTaskManager;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +41,7 @@ class ComponentInstallerTest {
     ComponentInstaller.Dialogs dialogs = mock(ComponentInstaller.Dialogs.class);
 
     ComponentInstaller installer = new ComponentInstallerImpl<>(
-        new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(), dialogs);
+        new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(), dialogs, new Callbacks());
 
     installer.install(module);
 
@@ -81,7 +82,7 @@ class ComponentInstallerTest {
 
     ComponentInstaller installer =
         new ComponentInstallerImpl<>(componentSource, new SimpleAsyncTaskManager(),
-            mock(ComponentInstaller.Dialogs.class));
+            mock(ComponentInstaller.Dialogs.class), new Callbacks());
 
     installer.install(module1);
 
@@ -120,7 +121,7 @@ class ComponentInstallerTest {
 
     ComponentInstaller installer =
         new ComponentInstallerImpl<>(componentSource, new SimpleAsyncTaskManager(),
-            mock(ComponentInstaller.Dialogs.class));
+            mock(ComponentInstaller.Dialogs.class), new Callbacks());
 
     List<Component> modules = new ArrayList<>();
     modules.add(module1);
@@ -154,7 +155,7 @@ class ComponentInstallerTest {
 
     ComponentInstaller installer = new ComponentInstallerImpl<>(
         new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(),
-        mock(ComponentInstaller.Dialogs.class));
+        mock(ComponentInstaller.Dialogs.class), new Callbacks());
 
     installer.install(module);
 
@@ -177,7 +178,7 @@ class ComponentInstallerTest {
 
     ComponentInstaller installer = new ComponentInstallerImpl<>(
         new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(),
-        mock(ComponentInstaller.Dialogs.class));
+        mock(ComponentInstaller.Dialogs.class), new Callbacks());
 
     installer.install(module);
 
@@ -201,7 +202,7 @@ class ComponentInstallerTest {
 
     ComponentInstaller installer =
         new ComponentInstallerImpl<>(componentSource, new SimpleAsyncTaskManager(),
-            mock(ComponentInstaller.Dialogs.class));
+            mock(ComponentInstaller.Dialogs.class), new Callbacks());
 
     installer.install(module);
 
@@ -234,7 +235,7 @@ class ComponentInstallerTest {
 
     ComponentInstaller installer =
         new ComponentInstallerImpl<>(componentSource, new SimpleAsyncTaskManager(),
-            mock(ComponentInstaller.Dialogs.class));
+            mock(ComponentInstaller.Dialogs.class), new Callbacks());
 
     List<Component> modules = new ArrayList<>();
     modules.add(dependentModule);
@@ -277,7 +278,7 @@ class ComponentInstallerTest {
 
     ComponentInstaller installer =
         new ComponentInstallerImpl<>(componentSource, new SimpleAsyncTaskManager(),
-            mock(ComponentInstaller.Dialogs.class));
+            mock(ComponentInstaller.Dialogs.class), new Callbacks());
 
     List<Component> modules = new ArrayList<>();
     modules.add(moduleA);
@@ -307,7 +308,7 @@ class ComponentInstallerTest {
     doReturn(true).when(dialogs).shouldOverwrite(component);
 
     ComponentInstaller installer = new ComponentInstallerImpl<>(
-        new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(), dialogs);
+        new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(), dialogs, new Callbacks());
     installer.install(component);
 
     verify(component).fetch();
@@ -329,7 +330,7 @@ class ComponentInstallerTest {
     doReturn(false).when(dialogs).shouldOverwrite(component);
 
     ComponentInstaller installer = new ComponentInstallerImpl<>(
-        new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(), dialogs);
+        new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(), dialogs, new Callbacks());
     installer.install(component);
 
     verify(component, never()).fetch();
@@ -349,7 +350,7 @@ class ComponentInstallerTest {
     ComponentInstaller.Dialogs dialogs = mock(ComponentInstaller.Dialogs.class);
 
     ComponentInstaller installer = new ComponentInstallerImpl<>(
-        new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(), dialogs);
+        new ModelExtensions.TestComponentSource(), new SimpleAsyncTaskManager(), dialogs, new Callbacks());
     installer.install(component);
 
     verify(dialogs, never()).shouldOverwrite(any());

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -58,7 +58,8 @@ class CourseTest {
         Collections.emptyMap(),
         Collections.emptyList(),
         new CourseHiddenElements(),
-        new Callbacks());
+        new Callbacks(),
+        false);
     Assertions.assertEquals("13", course.getId(),
         "The ID of the course should be the same as that given to the constructor");
     Assertions.assertEquals("Tester Course", course.getName(),
@@ -128,7 +129,9 @@ class CourseTest {
         // hiddenElements
         new CourseHiddenElements(),
         // callbacks
-        new Callbacks());
+        new Callbacks(),
+        // requireAuthenticationForModules
+        false);
     Assertions.assertSame(module2, course.getComponent("Awesome Module"),
         "Course#getModule should return the correct module");
   }
@@ -174,7 +177,9 @@ class CourseTest {
         // hiddenElements
         new CourseHiddenElements(),
         // callbacks
-        new Callbacks());
+        new Callbacks(),
+        // requireAuthenticationForModules
+        false);
     List<Component> autoInstalls = course.getAutoInstallComponents();
     Assertions.assertEquals(2, autoInstalls.size(), "The course has the correct auto-install components");
     Assertions.assertEquals(moduleName, autoInstalls.get(0).getName());

--- a/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/CourseTest.java
@@ -3,6 +3,7 @@ package fi.aalto.cs.apluscourses.model;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.Version;
 import java.io.StringReader;
@@ -56,7 +57,8 @@ class CourseTest {
         BuildInfo.INSTANCE.courseVersion,
         Collections.emptyMap(),
         Collections.emptyList(),
-        new CourseHiddenElements());
+        new CourseHiddenElements(),
+        new Callbacks());
     Assertions.assertEquals("13", course.getId(),
         "The ID of the course should be the same as that given to the constructor");
     Assertions.assertEquals("Tester Course", course.getName(),
@@ -124,7 +126,9 @@ class CourseTest {
         // pluginDependencies
         Collections.emptyList(),
         // hiddenElements
-        new CourseHiddenElements());
+        new CourseHiddenElements(),
+        // callbacks
+        new Callbacks());
     Assertions.assertSame(module2, course.getComponent("Awesome Module"),
         "Course#getModule should return the correct module");
   }
@@ -168,7 +172,9 @@ class CourseTest {
         // pluginDependencies
         Collections.emptyList(),
         // hiddenElements
-        new CourseHiddenElements());
+        new CourseHiddenElements(),
+        // callbacks
+        new Callbacks());
     List<Component> autoInstalls = course.getAutoInstallComponents();
     Assertions.assertEquals(2, autoInstalls.size(), "The course has the correct auto-install components");
     Assertions.assertEquals(moduleName, autoInstalls.get(0).getName());

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -159,10 +159,12 @@ public class ModelExtensions {
                       @NotNull Map<Long, Tutorial> tutorials,
                       @NotNull List<PluginDependency> pluginDependencies,
                       @NotNull CourseHiddenElements hiddenElements,
-                      @NotNull Callbacks callbacks) {
+                      @NotNull Callbacks callbacks,
+                      boolean requireAuthenticationForModules) {
       super(id, name, aplusUrl, languages, modules, libraries, exerciseModules, resourceUrls, vmOptions,
           optionalCategories, autoInstallComponentNames, replInitialCommands, replAdditionalArguments,
-          courseVersion, tutorials, pluginDependencies, hiddenElements, callbacks, null, "default");
+          courseVersion, tutorials, pluginDependencies, hiddenElements, callbacks, requireAuthenticationForModules,
+          null, "default");
       exerciseDataSource = new TestExerciseDataSource();
     }
 
@@ -212,6 +214,8 @@ public class ModelExtensions {
           new CourseHiddenElements(),
           // callbacks
           new Callbacks(),
+          // requireAuthenticationForModules
+          false,
           null, "default");
       this.exerciseDataSource = exerciseDataSource;
     }
@@ -275,6 +279,8 @@ public class ModelExtensions {
           new CourseHiddenElements(),
           // callbacks
           new Callbacks(),
+          // requireAuthenticationForModules
+          false,
           null,
           null,
           0);
@@ -459,6 +465,7 @@ public class ModelExtensions {
                                @NotNull List<PluginDependency> pluginDependencies,
                                @NotNull CourseHiddenElements hiddenElements,
                                @NotNull Callbacks callbacks,
+                               boolean requireAuthenticationForModules,
                                @Nullable String feedbackParser,
                                @Nullable String newsParser,
                                long courseLastModified) {
@@ -480,7 +487,8 @@ public class ModelExtensions {
           tutorials,
           pluginDependencies,
           hiddenElements,
-          callbacks
+          callbacks,
+          requireAuthenticationForModules
       );
     }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/ModelExtensions.java
@@ -5,6 +5,7 @@ import fi.aalto.cs.apluscourses.intellij.model.CommonLibraryProvider;
 import fi.aalto.cs.apluscourses.intellij.model.IntelliJCourse;
 import fi.aalto.cs.apluscourses.utils.APlusLogger;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import fi.aalto.cs.apluscourses.utils.Version;
@@ -103,7 +104,7 @@ public class ModelExtensions {
 
     @Override
     public @NotNull User getUser(@NotNull Authentication authentication) {
-      return new User(authentication, "test");
+      return new User(authentication, "test", "123456", 3333);
     }
 
     @Override
@@ -157,10 +158,11 @@ public class ModelExtensions {
                       @NotNull Version courseVersion,
                       @NotNull Map<Long, Tutorial> tutorials,
                       @NotNull List<PluginDependency> pluginDependencies,
-                      @NotNull CourseHiddenElements hiddenElements) {
+                      @NotNull CourseHiddenElements hiddenElements,
+                      @NotNull Callbacks callbacks) {
       super(id, name, aplusUrl, languages, modules, libraries, exerciseModules, resourceUrls, vmOptions,
           optionalCategories, autoInstallComponentNames, replInitialCommands, replAdditionalArguments,
-          courseVersion, tutorials, pluginDependencies, hiddenElements, null, "default");
+          courseVersion, tutorials, pluginDependencies, hiddenElements, callbacks, null, "default");
       exerciseDataSource = new TestExerciseDataSource();
     }
 
@@ -208,6 +210,8 @@ public class ModelExtensions {
           Collections.emptyList(),
           // hiddenElements
           new CourseHiddenElements(),
+          // callbacks
+          new Callbacks(),
           null, "default");
       this.exerciseDataSource = exerciseDataSource;
     }
@@ -269,6 +273,8 @@ public class ModelExtensions {
           Collections.emptyList(),
           // hiddenElements
           new CourseHiddenElements(),
+          // callbacks
+          new Callbacks(),
           null,
           null,
           0);
@@ -452,6 +458,7 @@ public class ModelExtensions {
                                @NotNull Map<Long, Tutorial> tutorials,
                                @NotNull List<PluginDependency> pluginDependencies,
                                @NotNull CourseHiddenElements hiddenElements,
+                               @NotNull Callbacks callbacks,
                                @Nullable String feedbackParser,
                                @Nullable String newsParser,
                                long courseLastModified) {
@@ -472,7 +479,8 @@ public class ModelExtensions {
           courseVersion,
           tutorials,
           pluginDependencies,
-          hiddenElements
+          hiddenElements,
+          callbacks
       );
     }
 

--- a/src/test/java/fi/aalto/cs/apluscourses/model/UserTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/UserTest.java
@@ -14,7 +14,7 @@ class UserTest {
     var user = exerciseDataSource.getUser(auth);
     Assertions.assertSame("test", user.getUserName());
     Assertions.assertSame("123456", user.getStudentId());
-    Assertions.assertSame(3333, user.getId());
+    Assertions.assertEquals(3333, user.getId());
     Assertions.assertSame(auth, user.getAuthentication());
   }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/model/UserTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/model/UserTest.java
@@ -13,6 +13,8 @@ class UserTest {
     var exerciseDataSource = new ModelExtensions.TestExerciseDataSource();
     var user = exerciseDataSource.getUser(auth);
     Assertions.assertSame("test", user.getUserName());
+    Assertions.assertSame("123456", user.getStudentId());
+    Assertions.assertSame(3333, user.getId());
     Assertions.assertSame(auth, user.getAuthentication());
   }
 }

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
@@ -47,7 +47,9 @@ class CourseProjectViewModelTest {
       // hiddenElements
       new CourseHiddenElements(),
       // callbacks
-      new Callbacks()
+      new Callbacks(),
+      // requireAuthenticationForModules
+      false
   );
 
   @Test

--- a/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/presentation/CourseProjectViewModelTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import fi.aalto.cs.apluscourses.model.Course;
 import fi.aalto.cs.apluscourses.model.ModelExtensions;
 import fi.aalto.cs.apluscourses.utils.BuildInfo;
+import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.observable.ValidationError;
 import java.util.Collections;
@@ -44,7 +45,9 @@ class CourseProjectViewModelTest {
       // pluginDependencies
       Collections.emptyList(),
       // hiddenElements
-      new CourseHiddenElements()
+      new CourseHiddenElements(),
+      // callbacks
+      new Callbacks()
   );
 
   @Test


### PR DESCRIPTION
# Description of the PR
This PR adds the following features:
1. When linking IntelliJ course to an A+ course: if there is only one language available, it is selected automatically.
2. Course configuration file gained a new, **optional** boolean field: `requireAuthenticationForModules`. If true, the "Modules" buttons is hidden when no A+ token is provided. The option default to false.
3. Course configuration file gained a new, **optional** object: `callbacks`. For now, the only thing you can do with it is:
```
"callbacks": {
  "postDownloadModule": [
    "AddModuleWatermark"
  ]
},
```
which will run the AddModuleWatermark callback after a module is downloaded. It is used to add watermarks in TRAKY courses. The available callback identifiers (strings) are defined somewhere in the source code.

In the future, the callbacks object can be expanded with more callbacks and callback types.