### PR TITLE
Delay setting background colors until after the component is added

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'scala'
     id 'checkstyle'
     id 'com.github.alisiikh.scalastyle' version '3.5.0'
-    id 'org.jetbrains.intellij' version '1.13.3'
+    id 'org.jetbrains.intellij' version '1.15.0'
     id 'org.sonarqube' version '4.3.0.3225'
     id 'jacoco'
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/BannerPanel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/BannerPanel.java
@@ -4,6 +4,7 @@ import com.intellij.ui.JBColor;
 import com.intellij.ui.components.panels.OpaquePanel;
 import com.intellij.util.ui.JBUI;
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.Dimension;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
@@ -14,18 +15,21 @@ public class BannerPanel extends JPanel {
   @NotNull
   private final JLabel bannerText = new JLabel();
 
+  @NotNull
+  private final JPanel containerPanel;
+
   /**
    * Constructor for the banner.
    */
   public BannerPanel() {
     super(new BorderLayout());
 
-    JPanel panel = new OpaquePanel(new BorderLayout());
-    panel.add(BorderLayout.CENTER, bannerText);
-    panel.setBorder(JBUI.Borders.empty(5, 0, 5, 5));
-    panel.setMinimumSize(new Dimension(0, 0));
+    containerPanel = new OpaquePanel(new BorderLayout());
+    containerPanel.add(BorderLayout.CENTER, bannerText);
+    containerPanel.setBorder(JBUI.Borders.empty(5, 0, 5, 5));
+    containerPanel.setMinimumSize(new Dimension(0, 0));
 
-    add(BorderLayout.CENTER, panel);
+    add(BorderLayout.CENTER, containerPanel);
 
     setBorder(BorderFactory.createCompoundBorder(
         BorderFactory.createMatteBorder(0, 0, 1, 0, JBColor.border()),
@@ -35,5 +39,10 @@ public class BannerPanel extends JPanel {
 
   public void setText(String text) {
     bannerText.setText(text);
+  }
+
+  public void setBannerColor(@NotNull Color color) {
+    containerPanel.setBackground(color);
+    setBackground(color);
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/BannerView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/BannerView.java
@@ -34,7 +34,7 @@ public class BannerView {
       panel.setVisible(text != null);
     }, true);
 
-    this.colorBindable = new Bindable<>(banner, BannerPanel::setBackground, true);
+    this.colorBindable = new Bindable<>(banner, BannerPanel::setBannerColor, true);
   }
 
   /**

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/ReplBannerPanel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/ReplBannerPanel.java
@@ -16,20 +16,20 @@ import java.awt.event.MouseEvent;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import org.jetbrains.annotations.NotNull;
 
 public class ReplBannerPanel extends JPanel {
 
   private boolean isPermanentlyHidden = false;
+
+  @NotNull
+  private final JPanel containerPanel;
 
   /**
    * Constructor for the banner.
    */
   public ReplBannerPanel() {
     super(new BorderLayout());
-
-    final JPanel panel = new OpaquePanel(new FlowLayout(FlowLayout.LEFT));
-    panel.setBorder(JBUI.Borders.empty(5, 0, 5, 5));
-    panel.setMinimumSize(new Dimension(0, 0));
 
     final JLabel infoText = new JLabel(getText("ui.repl.warning.description"));
     final JLabel dontShowOnceText = new JLabel(getText("ui.repl.warning.ignoreOnce"));
@@ -55,15 +55,17 @@ public class ReplBannerPanel extends JPanel {
       }
     });
 
-    panel.add(infoText);
-    panel.add(new JLabel("|"));
-    panel.add(dontShowOnceText);
-    panel.add(new JLabel("|"));
-    panel.add(neverAskAgainText);
+    containerPanel = new OpaquePanel(new FlowLayout(FlowLayout.LEFT));
+    containerPanel.setBorder(JBUI.Borders.empty(5, 0, 5, 5));
+    containerPanel.setMinimumSize(new Dimension(0, 0));
+    containerPanel.add(infoText);
+    containerPanel.add(new JLabel("|"));
+    containerPanel.add(dontShowOnceText);
+    containerPanel.add(new JLabel("|"));
+    containerPanel.add(neverAskAgainText);
 
-    add(panel);
+    add(containerPanel);
 
-    setBackground(new JBColor(new Color(200, 0, 0), new Color(100, 0, 0)));
     setBorder(BorderFactory.createCompoundBorder(
         BorderFactory.createMatteBorder(0, 0, 1, 0, JBColor.border()),
         BorderFactory.createEmptyBorder(0, 5, 0, 5))
@@ -72,8 +74,14 @@ public class ReplBannerPanel extends JPanel {
 
   @Override
   public void setVisible(boolean isVisible) {
+    if (isVisible) {
+      final JBColor bgColor = new JBColor(new Color(200, 0, 0), new Color(100, 0, 0));
+      containerPanel.setBackground(bgColor);
+      setBackground(bgColor);
+    }
+
     super.setVisible(isVisible
-        && !this.isPermanentlyHidden
+        && !isPermanentlyHidden
         && !PluginSettings.getInstance().shouldHideReplModuleChangedWarning());
   }
 }


### PR DESCRIPTION
# Description of the PR
Fixes #1029

The background colors in our custom JPanels are now working correctly in the new UI. Previous IntelliJ versions (and the old UI) are not affected by this code change.

Reason for this change (**warning: speculation zone**)
Color-wise, the new UI is beautifully uniform. It seems implausible that all UI developers at JetBrains agreed to rewrite their Swing components, so something else must be going on.

What I believe is happening is that whenever a new Swing component is added to the component tree, the background color of all JPanels inside is reset to the theme's default color. Therefore, to override this behavior, we need to set the colors after adding the components.

In the course ended banner, we just needed to add changing color of the internal JPanel.
In the REPL banner, we delayed changing the color until the banner is actually shown.

![untitled](https://github.com/Aalto-LeTech/aplus-courses/assets/73069541/86927ab1-25b5-4880-986e-063e91912a2d)
