### PR TITLE
Update A+ Docker build script name

### DIFF
--- a/src/test/java/fi/aalto/cs/apluscourses/integration/ApiTest.java
+++ b/src/test/java/fi/aalto/cs/apluscourses/integration/ApiTest.java
@@ -38,7 +38,7 @@ class ApiTest {
         .body(firstExercise + ".points", equalTo(60))
         .body(firstExercise + ".passed", equalTo(true))
         .body(firstExercise + ".best_submission",
-            equalTo("http://localhost:8000/api/v2/submissions/401/"))
+            equalTo("http://localhost:8000/api/v2/submissions/401"))
         .body(firstExercise + ".submissions[0]", containsString("402"))
         .body(firstExercise + ".submissions[1]", containsString("401"))
         .body(firstExercise + ".submissions[2]", containsString("400"));
@@ -122,7 +122,7 @@ class ApiTest {
         .contentType(ContentType.JSON)
         .body(
             "exercise.html_url",
-            equalTo("http://localhost:8000/test-course/test-instance/first-module/easy-exercise/")
+            equalTo("http://localhost:8000/test-aplus-course/test-instance/first-module/easy-exercise/")
         )
         .body("late_penalty_applied", equalTo(null))
         .body("status", equalTo("ready"));

--- a/start_local_a+_env.sh
+++ b/start_local_a+_env.sh
@@ -3,11 +3,11 @@
 # preparing and compiling the A+ env components (https://apluslms.github.io/guides/quick/)
 git clone --depth 1 https://github.com/apluslms/aplus-manual.git my_new_course &&
 cd my_new_course &&
-git checkout ea39d0144dc97e5438f6c19a70085a03708ccdee &&
 wget https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 && chmod +x yq_linux_amd64 &&
 ./yq_linux_amd64 eval -i '.services.plus.volumes += ["../tools/aplus-init.sh:/srv/aplus-init.sh:ro", "../tools/simple_course.py:/srv/simple_course.py:ro"]' docker-compose.yml &&
 git submodule init &&
 git submodule update &&
+git checkout ea39d0144dc97e5438f6c19a70085a03708ccdee &&
 chmod +x docker-fast-compile.sh && ./docker-fast-compile.sh &&
 # modifying the initial script (just cutting off the last part of it), so it would run in the background
 head -102 docker-up.sh > docker-up-custom.sh &&

--- a/start_local_a+_env.sh
+++ b/start_local_a+_env.sh
@@ -3,11 +3,12 @@
 # preparing and compiling the A+ env components (https://apluslms.github.io/guides/quick/)
 git clone --depth 1 https://github.com/apluslms/aplus-manual.git my_new_course &&
 cd my_new_course &&
+git checkout ea39d0144dc97e5438f6c19a70085a03708ccdee &&
 wget https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 && chmod +x yq_linux_amd64 &&
 ./yq_linux_amd64 eval -i '.services.plus.volumes += ["../tools/aplus-init.sh:/srv/aplus-init.sh:ro", "../tools/simple_course.py:/srv/simple_course.py:ro"]' docker-compose.yml &&
 git submodule init &&
 git submodule update &&
-chmod +x docker-compile.sh && ./docker-compile.sh &&
+chmod +x docker-fast-compile.sh && ./docker-fast-compile.sh &&
 # modifying the initial script (just cutting off the last part of it), so it would run in the background
 head -102 docker-up.sh > docker-up-custom.sh &&
 # adding an execution permission to the newly created script

--- a/start_local_a+_env.sh
+++ b/start_local_a+_env.sh
@@ -7,8 +7,7 @@ wget https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 &&
 ./yq_linux_amd64 eval -i '.services.plus.volumes += ["../tools/aplus-init.sh:/srv/aplus-init.sh:ro", "../tools/simple_course.py:/srv/simple_course.py:ro"]' docker-compose.yml &&
 git submodule init &&
 git submodule update &&
-git checkout ea39d0144dc97e5438f6c19a70085a03708ccdee &&
-chmod +x docker-fast-compile.sh && ./docker-fast-compile.sh &&
+chmod +x docker-compile.sh && ./docker-compile.sh &&
 # modifying the initial script (just cutting off the last part of it), so it would run in the background
 head -102 docker-up.sh > docker-up-custom.sh &&
 # adding an execution permission to the newly created script

--- a/start_local_a+_env.sh
+++ b/start_local_a+_env.sh
@@ -7,7 +7,7 @@ wget https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 &&
 ./yq_linux_amd64 eval -i '.services.plus.volumes += ["../tools/aplus-init.sh:/srv/aplus-init.sh:ro", "../tools/simple_course.py:/srv/simple_course.py:ro"]' docker-compose.yml &&
 git submodule init &&
 git submodule update &&
-chmod +x docker-fast-compile.sh && ./docker-fast-compile.sh &&
+chmod +x docker-compile.sh && ./docker-compile.sh &&
 # modifying the initial script (just cutting off the last part of it), so it would run in the background
 head -102 docker-up.sh > docker-up-custom.sh &&
 # adding an execution permission to the newly created script

--- a/tools/simple_course.py
+++ b/tools/simple_course.py
@@ -97,7 +97,7 @@ def main():
 
     course0 = Course()
     course0.name = 'Test Course'
-    course0.url = 'test-course'
+    course0.url = 'test-aplus-course'
     course0.save()
 
     instance0 = CourseInstance(id=100, course=course0)


### PR DESCRIPTION
# Description of the PR
The A+ team has deleted some build scripts, so we need to adapt accordingly.
It seems that the current `docker-compile.sh` is exactly the same as the previous `docker-fast-compile.sh`, so functionally nothing changes.

I'm not sure why the change from `test-course` is necessary. Without it, the A+ container complains about "duplicate course URL" so maybe such a test course already exists by default?