### PR TITLE
Change some interface constructions to appease Plugin Verifier

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/FileFinder.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/FileFinder.java
@@ -19,9 +19,16 @@ public interface FileFinder {
         .orElseThrow(() -> new FileDoesNotExistException(directory, filename));
   }
 
+  /**
+   * Resolves an array of filenames to an array of Paths.
+   */
   @NotNull
   default Path[] findFiles(@NotNull Path directory, @NotNull String[] filenames)
       throws FileDoesNotExistException {
-    return ArrayUtil.mapArray(filenames, filename -> findFile(directory, filename), Path[]::new);
+    Path[] paths = new Path[filenames.length];
+    for (int i = 0; i < filenames.length; i++) {
+      paths[i] = findFile(directory, filenames[i]);
+    }
+    return paths;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/async/TaskManager.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/async/TaskManager.java
@@ -44,9 +44,16 @@ public interface TaskManager<T> {
    * given to this function, are joined.
    */
   default T all(List<T> tasks) {
-    return fork(() -> {
-      for (T task : tasks) {
-        join(task);
+    // Please do not change the "new Runnable" construction to a lambda, even if IntelliJ suggests it.
+    // Functionality-wise nothing would change, but calling default interface methods from a lambda triggers
+    // a false positive in the JetBrains Plugin Verifier.
+    // If you change this anyway, run the Plugin Verifier locally to ensure that it does not erroneously complain.
+    return fork(new Runnable() {
+      @Override
+      public void run() {
+        for (T task : tasks) {
+          join(task);
+        }
       }
     });
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/utils/callbacks/AddModuleWatermark.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,16 +44,14 @@ public class AddModuleWatermark {
     final String watermark = createWatermark(userId);
 
     try (Stream<String> lineStream = Files.lines(path)) {
-      var newLines = lineStream.map(line -> {
+      var newLinesMutable = lineStream.map(line -> {
         if (line.equals(ENCODING_LINE) || line.equals(ENCODING_LINE_WITH_UNICODE)) {
           return "";
         } else if (line.trim().startsWith("#")) {
           return line.replaceFirst("#", "#" + watermark);
         }
         return line;
-      }).toList();
-
-      var newLinesMutable = new ArrayList<>(newLines);
+      }).collect(Collectors.toCollection(ArrayList::new));
 
       newLinesMutable.add(0, ENCODING_LINE);
       newLinesMutable.add(1, "# Nimi: " + studentName);


### PR DESCRIPTION
# Description of the PR
Fixes #1035 
The following changes have been made:
- `FileFinder.findFiles` - invoking default interface method in lambda has been replaced by an old-fashioned for-loop
- `TaskManager.all` - replaced lambda with an old-fashioned "new Runnable" class instantiation
- `AddModuleWatermark.addWatermark` - here I noticed that the Plugin Verifier was complaining about missing method `toList`. It seems that `toList` is only available since Java 16, so I replaced that with a Java 11-compatible construction (and a better one, IMO)