### PR TITLE
More lenient exercise JSON parsing

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/services/PluginSettings.java
@@ -205,6 +205,8 @@ public class PluginSettings implements MainViewModelProvider, DefaultGroupIdSett
       // instructed to turn the project into a course project for an example when the token is
       // missing.
       mainViewModel.toolWindowCardViewModel.setAPlusProject(true);
+      mainViewModel.toolWindowCardViewModel.setModuleButtonRequiresLogin(
+          courseProject.getCourse().requiresLoginForModules());
       courseProject.user.addValueObserver(mainViewModel, MainViewModel::userChanged);
       courseProject.user.addSimpleObserver(courseProject, courseP -> courseP.getCourseUpdater().restart());
       var exercisesViewModel = new ExercisesTreeViewModel(new ExercisesTree(), new Options());

--- a/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionInfo.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/SubmissionInfo.java
@@ -35,7 +35,13 @@ public class SubmissionInfo {
       return new SubmissionInfo(Collections.emptyMap());
     }
 
-    JSONArray formSpec = exerciseInfo.getJSONArray("form_spec");
+    JSONArray formSpec = exerciseInfo.optJSONArray("form_spec");
+    if (formSpec == null) {
+      // Some assignments, such as https://plus.cs.aalto.fi/api/v2/exercises/50181/ don't have the
+      // form_spec field despite having exercise_info.
+      return new SubmissionInfo(Collections.emptyMap());
+    }
+
     JSONObject localizationInfo = exerciseInfo.getJSONObject("form_i18n");
     Map<String, List<SubmittableFile>> files = new HashMap<>();
 


### PR DESCRIPTION
# Description of the PR
While testing TRAKY courses, I noticed that some multiple-choice questions have an `exercise_info` field but not `form_spec`. This trips up the plugin, since that didn't happen with O1.

(Also fixes a tiny oversight when setting the "should hide 'Modules' button" -property)