### PR TITLE
Specify execution thread for AnAction's update() method

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/APlusAuthenticationAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/APlusAuthenticationAction.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
@@ -64,6 +65,11 @@ public class APlusAuthenticationAction extends DumbAwareAction {
   @Override
   public void update(@NotNull AnActionEvent e) {
     e.getPresentation().setEnabled(courseProjectProvider.getCourseProject(e.getProject()) != null);
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/CourseProjectAction.java
@@ -1,6 +1,7 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
 import com.intellij.concurrency.JobScheduler;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
@@ -279,6 +280,11 @@ public class CourseProjectAction extends AnAction {
     // This action is available only if a non-default project is open
     Project project = e.getProject();
     e.getPresentation().setEnabledAndVisible(project != null && !project.isDefault());
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @FunctionalInterface

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/DownloadSubmissionAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/DownloadSubmissionAction.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
@@ -101,5 +102,10 @@ public class DownloadSubmissionAction extends AnAction {
           && selectedExercise != null
           && (selectedExercise.isSubmittable() || selectedItem.getModel() instanceof DummySubmissionResult));
     }
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ExportModuleAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ExportModuleAction.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.module.Module;
@@ -78,6 +79,11 @@ public class ExportModuleAction extends AnAction {
   public void update(@NotNull AnActionEvent e) {
     Project project = e.getProject();
     e.getPresentation().setEnabled(project != null && !project.isDefault());
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/InstallModuleAction.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
@@ -61,6 +62,11 @@ public class InstallModuleAction extends DumbAwareAction {
     boolean isModuleSelected = courseViewModel != null
         && !courseViewModel.getModules().isSelectionEmpty();
     e.getPresentation().setEnabled(isModuleSelected);
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/LogInOutAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/LogInOutAction.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import fi.aalto.cs.apluscourses.dal.PasswordStorage;
@@ -49,6 +50,11 @@ public class LogInOutAction extends DumbAwareAction {
         ? getText("presentation.userDropdown.logOut")
         : getText("presentation.userDropdown.logIn");
     e.getPresentation().setText(text);
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   private boolean isLoggedIn(@NotNull AnActionEvent e) {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenDocumentationAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenDocumentationAction.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
@@ -42,6 +43,11 @@ public class OpenDocumentationAction extends DumbAwareAction {
     CourseViewModel courseViewModel =
         mainViewModelProvider.getMainViewModel(e.getProject()).courseViewModel.get();
     e.getPresentation().setEnabled(courseViewModel != null && courseViewModel.getModules().canOpenDocumentation());
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenItemAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OpenItemAction.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import com.intellij.openapi.project.Project;
@@ -74,6 +75,11 @@ public class OpenItemAction<T> extends DumbAwareAction {
   public void update(@NotNull AnActionEvent e) {
     var project = e.getProject();
     e.getPresentation().setEnabled(project != null && getTreeViewModel(project) != null);
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Nullable

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OptionsActionGroup.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/OptionsActionGroup.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
@@ -32,6 +33,11 @@ public abstract class OptionsActionGroup extends DefaultActionGroup implements D
   public void update(@NotNull AnActionEvent e) {
     e.getPresentation().setEnabled(isAvailable(e.getProject()));
     Toggleable.setSelected(e.getPresentation(), getOptionsInternal(e).isAnyActive());
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   private @NotNull Options getOptionsInternal(@Nullable AnActionEvent e) {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ReadAllNewsAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ReadAllNewsAction.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import fi.aalto.cs.apluscourses.intellij.services.MainViewModelProvider;
@@ -41,5 +42,10 @@ public class ReadAllNewsAction extends DumbAwareAction {
     var project = e.getProject();
     var mainViewModel = mainViewModelProvider.getMainViewModel(project);
     e.getPresentation().setEnabled(mainViewModel.newsTreeViewModel.get() != null);
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/RefreshExercisesAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/RefreshExercisesAction.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import fi.aalto.cs.apluscourses.intellij.services.CourseProjectProvider;
@@ -34,6 +35,11 @@ public class RefreshExercisesAction extends DumbAwareAction {
     }
     e.getPresentation().setEnabled(
         project != null && courseProject != null && courseProject.getAuthentication() != null);
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/RefreshModulesAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/RefreshModulesAction.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.DumbAwareAction;
 import fi.aalto.cs.apluscourses.intellij.services.CourseProjectProvider;
@@ -24,6 +25,11 @@ public class RefreshModulesAction extends DumbAwareAction {
     var project = e.getProject();
     e.getPresentation().setEnabled(
         project != null && courseProjectProvider.getCourseProject(project) != null);
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SelectStudentAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SelectStudentAction.java
@@ -1,5 +1,6 @@
 package fi.aalto.cs.apluscourses.intellij.actions;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import fi.aalto.cs.apluscourses.intellij.notifications.DefaultNotifier;
@@ -80,5 +81,10 @@ public class SelectStudentAction extends AnAction {
     e.getPresentation().setVisible(assistantModeProvider.isAssistantMode());
     var courseProject = courseProjectProvider.getCourseProject(e.getProject());
     e.getPresentation().setEnabled(courseProject != null && courseProject.getAuthentication() != null);
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ShowFeedbackAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/ShowFeedbackAction.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getAndReplaceText;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.fileEditor.FileEditorManager;
@@ -158,6 +159,11 @@ public class ShowFeedbackAction extends AnAction {
     if (selectedSubmissionResult == null || !selectedSubmissionResult.getModel().getExercise().isSubmittable()) {
       e.getPresentation().setEnabled(false);
     }
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   public void setSubmissionResult(@Nullable SubmissionResult submissionResult) {

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/SubmitExerciseAction.java
@@ -6,6 +6,7 @@ import static icons.PluginIcons.ACCENT_COLOR;
 
 import com.intellij.history.LocalHistory;
 import com.intellij.openapi.actionSystem.ActionPlaces;
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -198,6 +199,11 @@ public class SubmitExerciseAction extends AnAction {
     if ((ActionPlaces.TOOLWINDOW_POPUP).equals(e.getPlace()) && !e.getPresentation().isEnabled()) {
       e.getPresentation().setVisible(false);
     }
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @Override

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/TutorialAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/TutorialAction.java
@@ -3,6 +3,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 import static com.intellij.openapi.actionSystem.ex.ActionUtil.isDumbMode;
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.impl.ActionToolbarImpl;
@@ -146,6 +147,11 @@ public class TutorialAction extends AnAction implements DumbAware {
     } else {
       e.getPresentation().setText(getText("intellij.action.TutorialAction.startTutorial"));
     }
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @FunctionalInterface

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/TutorialActionGroup.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/TutorialActionGroup.java
@@ -3,6 +3,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getAndReplaceText;
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
@@ -97,6 +98,11 @@ public class TutorialActionGroup extends DefaultActionGroup implements DumbAware
         e.getPresentation().setEnabled(tutorial.getUnlockedIndex() >= index);
       }
       super.update(e);
+    }
+
+    @Override
+    public @NotNull ActionUpdateThread getActionUpdateThread() {
+      return ActionUpdateThread.BGT;
     }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/TutorialProgressAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/TutorialProgressAction.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getAndReplaceText;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.Presentation;
@@ -51,6 +52,11 @@ public class TutorialProgressAction extends ComboBoxAction implements DumbAware,
       e.getPresentation().setText(getAndReplaceText("presentation.navbar.progress",
           tutorialViewModel.getCurrentTaskIndex(), tutorialViewModel.getTasksAmount()));
     }
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 
   @NotNull

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/UserActionGroup.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/UserActionGroup.java
@@ -3,6 +3,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getAndReplaceText;
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.openapi.actionSystem.impl.ActionButton;
@@ -38,5 +39,10 @@ public class UserActionGroup extends DefaultActionGroup implements DumbAware {
       e.getPresentation().setIcon(icon);
       e.getPresentation().setText(text);
     }
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/UserNameAction.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/intellij/actions/UserNameAction.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.intellij.actions;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import fi.aalto.cs.apluscourses.intellij.services.CourseProjectProvider;
@@ -33,5 +34,10 @@ public class UserNameAction extends AnAction {
       userName = userName.equals("") ? getText("presentation.userDropdown.notLoggedIn") : userName;
       e.getPresentation().setText(userName);
     }
+  }
+
+  @Override
+  public @NotNull ActionUpdateThread getActionUpdateThread() {
+    return ActionUpdateThread.BGT;
   }
 }

--- a/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ConsoleExecuteAction.scala
+++ b/src/main/scala/org/jetbrains/plugins/scala/console/apluscourses/ConsoleExecuteAction.scala
@@ -9,7 +9,7 @@
 
 package org.jetbrains.plugins.scala.console.apluscourses
 
-import com.intellij.openapi.actionSystem.{AnActionEvent, CommonDataKeys}
+import com.intellij.openapi.actionSystem.{ActionUpdateThread, AnActionEvent, CommonDataKeys}
 import com.intellij.openapi.util.TextRange
 import fi.aalto.cs.apluscourses.intellij.Repl
 import org.jetbrains.plugins.scala.console.ScalaConsoleInfo
@@ -99,4 +99,6 @@ class ConsoleExecuteAction extends ScalaConsoleExecuteAction {
 
     console.textSent(text)
   }
+
+  override def getActionUpdateThread: ActionUpdateThread = ActionUpdateThread.BGT
 }

--- a/start_local_a+_env.sh
+++ b/start_local_a+_env.sh
@@ -9,7 +9,7 @@ git submodule init &&
 git submodule update &&
 chmod +x docker-compile.sh && ./docker-compile.sh &&
 # modifying the initial script (just cutting off the last part of it), so it would run in the background
-head -103 docker-up.sh > docker-up-custom.sh &&
+head -104 docker-up.sh > docker-up-custom.sh &&
 # adding an execution permission to the newly created script
 chmod +x docker-up-custom.sh &&
 ./docker-up-custom.sh &&


### PR DESCRIPTION
# Description of the PR
Fixes #1050 

Apparently in IntelliJ 2022.3 there was an update (heh) which requires all AnActions to override `getActionUpdateThread()` in order to specify the thread on which `update()` will run (`actionPerformed` still executes on EDT). If not overridden, it defaults to slow EDT rather than fast background thread.

`ActionUpdateThread.BGT` is recommended for all actions unless `update()` accesses Swing components, which is not the case in our plugin.