### PR TITLE
Fix miscellaneous bugs and incompatibilities

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Course.java
@@ -5,7 +5,6 @@ import fi.aalto.cs.apluscourses.utils.BuildInfo;
 import fi.aalto.cs.apluscourses.utils.Callbacks;
 import fi.aalto.cs.apluscourses.utils.CourseHiddenElements;
 import fi.aalto.cs.apluscourses.utils.CoursesClient;
-import fi.aalto.cs.apluscourses.utils.JsonUtil;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import fi.aalto.cs.apluscourses.utils.ResourceException;
 import fi.aalto.cs.apluscourses.utils.Resources;

--- a/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/Exercise.java
@@ -4,7 +4,6 @@ import fi.aalto.cs.apluscourses.utils.APlusLocalizationUtil;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;

--- a/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/model/ExerciseDataSource.java
@@ -4,7 +4,6 @@ import fi.aalto.cs.apluscourses.utils.cache.CachePreference;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/ProgressViewModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/ProgressViewModel.java
@@ -44,7 +44,7 @@ public class ProgressViewModel {
    */
   public void stopAll() {
     synchronized (lock) {
-      progresses.forEach(Progress::finish);
+      new ArrayDeque<>(progresses).forEach(Progress::finish);
     }
     this.updateValues();
   }

--- a/src/main/java/fi/aalto/cs/apluscourses/presentation/ReplConfigurationFormModel.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/presentation/ReplConfigurationFormModel.java
@@ -46,9 +46,10 @@ public class ReplConfigurationFormModel {
   public static List<String> getScalaModuleNames(@NotNull Module[] modules) {
     return Arrays.stream(modules)
         .filter(module -> {
-          //  Scala modules are of a "JAVA_MODULE" type,
-          //  so it the way to distinct them from SBT-built ones.
-          return ModuleType.get(module).getName().equals("JAVA_MODULE");
+          // Java and Scala modules used to be called "JAVA_MODULE".
+          // Then, it was changes to "Java Module". We will check for both.
+          String moduleName = ModuleType.get(module).getName();
+          return moduleName.equalsIgnoreCase("JAVA_MODULE") || moduleName.equalsIgnoreCase("Java Module");
         })
         .map(Module::getName)
         .collect(Collectors.toList());

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationDialog.java
@@ -2,7 +2,6 @@ package fi.aalto.cs.apluscourses.ui.repl;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
-import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.uiDesigner.core.GridConstraints;
 import fi.aalto.cs.apluscourses.ui.base.DialogBaseHelper;
 import javax.swing.JButton;

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/repl/ReplConfigurationDialog.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.ui.repl;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.uiDesigner.core.GridConstraints;
 import fi.aalto.cs.apluscourses.ui.base.DialogBaseHelper;
 import javax.swing.JButton;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,7 +41,8 @@
     <actions>
         <group id="fi.aalto.cs.apluscourses.intellij.actions.ActionGroups.MENU_ACTIONS"
                text="A+"
-               description="Actions for A+ menu">
+               description="Actions for A+ menu"
+               popup="true">
             <add-to-group group-id="MainMenu" anchor="last"/>
             <action id="fi.aalto.cs.apluscourses.intellij.actions.CourseProjectAction"
                     class="fi.aalto.cs.apluscourses.intellij.actions.CourseProjectAction"


### PR DESCRIPTION
# Description of the PR
Closes #1085

This PR fixes four issues encountered with the latest version of IntelliJ.

**Issue 1**: the A+ menu strip was not visible in the top menu bar.
**Fix**: added `popup = "true"` to the group. IMO this shouldn't have even worked in the past, but now it finally broke. (Solution found here, posted by some JetBrains guy: https://youtrack.jetbrains.com/issue/IDEA-333796)

**Issue 2**: the exception `java.lang.Throwable: Thread context was already set: com.intellij.openapi.actionSystem.ex.ActionContextElement` upon opening the REPL launch dialog box.
**Fix**: we need to reset the thread context before starting a new message loop inside of an existing message loop. Other dialog boxes in our plugin are probably fine because they use DialogWrapper which seems to handle the thread context on its own. (Info from another JetBrains guy: https://intellij-support.jetbrains.com/hc/en-us/community/posts/14397678486418--Thread-context-was-already-set-CoroutineName-commit-workflow-when-showing-window-during-commit-check)

**Issue 3**: modules were not showing up in the REPL launch dialog.
**Fix**: it turns out that the Java modules now have the identifier "Java Module" and not "JAVA_MODULE". Quite an easy fix, but the issue certainly rubbed me the wrong way.
[note: the NullPointerException mentioned in linked issue #1085 was a result of this problem, so it will also disappear]

**Issue 4**: `java.util.ConcurrentModificationException` in `ProgressViewModel.stopAll`. This was because `forEach` was indirectly invoking a method which modified the collection that was being iterated.
**Fix**: just iterate over a copy of the collection.