### PR TITLE
Replace JOptionPane dialogs with IntelliJ platform API messages

### DIFF
--- a/src/main/java/fi/aalto/cs/apluscourses/ui/DuplicateSubmissionDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/DuplicateSubmissionDialog.java
@@ -2,7 +2,7 @@ package fi.aalto.cs.apluscourses.ui;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
-import javax.swing.JOptionPane;
+import com.intellij.openapi.ui.Messages;
 
 public class DuplicateSubmissionDialog {
 
@@ -17,14 +17,10 @@ public class DuplicateSubmissionDialog {
   public static boolean showDialog() {
     final String[] options = { getText("ui.duplicateDialog.yesOption"), getText("ui.duplicateDialog.noOption") };
 
-    return JOptionPane.showOptionDialog(null,
-        getText("ui.duplicateDialog.content"),
+    return Messages.showDialog(getText("ui.duplicateDialog.content"),
         getText("ui.duplicateDialog.title"),
-        JOptionPane.YES_NO_OPTION,
-        JOptionPane.QUESTION_MESSAGE,
-        null,
         options,
-        options[1]
-    ) == 0;
+        1,
+        null) == 0;
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/FileSaveView.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/FileSaveView.java
@@ -7,10 +7,10 @@ import com.intellij.openapi.fileChooser.FileChooserFactory;
 import com.intellij.openapi.fileChooser.FileSaverDescriptor;
 import com.intellij.openapi.fileChooser.FileSaverDialog;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFileWrapper;
 import fi.aalto.cs.apluscourses.presentation.FileSaveViewModel;
 import java.nio.file.InvalidPathException;
-import javax.swing.JOptionPane;
 import org.jetbrains.annotations.NotNull;
 
 public class FileSaveView implements Dialog {
@@ -44,10 +44,9 @@ public class FileSaveView implements Dialog {
           viewModel.setPath(file.getFile().toPath());
           return true;
         } catch (InvalidPathException e) {
-          JOptionPane.showMessageDialog(null,
+          Messages.showErrorDialog(
               getAndReplaceText("ui.exportModule.invalidPath.message", e.getReason()),
-              getText("ui.exportModule.invalidPath.title"),
-              JOptionPane.ERROR_MESSAGE);
+              getText("ui.exportModule.invalidPath.title"));
           continue;
         }
       }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
@@ -2,6 +2,7 @@ package fi.aalto.cs.apluscourses.ui;
 
 import static fi.aalto.cs.apluscourses.utils.PluginResourceBundle.getText;
 
+import com.intellij.concurrency.ThreadContext;
 import com.intellij.icons.AllIcons;
 import com.intellij.ide.BrowserUtil;
 import com.intellij.ui.components.JBLabel;
@@ -33,7 +34,12 @@ public class IntegrityCheckDialog {
     box.add(Box.createVerticalStrut(10));
     box.add(linkLabel);
 
-    JOptionPane.showMessageDialog(null, JBUI.Panels.simplePanel(box), getText("ui.integrityDialog.title"),
-        JOptionPane.ERROR_MESSAGE);
+    // This dialog box cannot be easily converted to Messages.showErrorDialog because the latter only accepts a string
+    // as message text. Here we have a Swing component that includes a clickable link.
+    // We'll go with the second-best solution, which is to reset the thread context manually.
+    try (var ignored = ThreadContext.resetThreadContext()) {
+      JOptionPane.showMessageDialog(null, JBUI.Panels.simplePanel(box), getText("ui.integrityDialog.title"),
+          JOptionPane.ERROR_MESSAGE);
+    }
   }
 }

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/IntegrityCheckDialog.java
@@ -36,7 +36,7 @@ public class IntegrityCheckDialog {
 
     // This dialog box cannot be easily converted to Messages.showErrorDialog because the latter only accepts a string
     // as message text. Here we have a Swing component that includes a clickable link.
-    // We'll go with the second-best solution, which is to reset the thread context manually.
+    // We'll go with the second-best solution, which is to temporarily reset the thread context manually.
     try (var ignored = ThreadContext.resetThreadContext()) {
       JOptionPane.showMessageDialog(null, JBUI.Panels.simplePanel(box), getText("ui.integrityDialog.title"),
           JOptionPane.ERROR_MESSAGE);

--- a/src/main/java/fi/aalto/cs/apluscourses/ui/utils/PluginInstallerDialogs.java
+++ b/src/main/java/fi/aalto/cs/apluscourses/ui/utils/PluginInstallerDialogs.java
@@ -7,7 +7,6 @@ import com.intellij.openapi.ui.Messages;
 import fi.aalto.cs.apluscourses.utils.PluginDependency;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.swing.JOptionPane;
 import org.jetbrains.annotations.NotNull;
 
 public class PluginInstallerDialogs {
@@ -22,25 +21,24 @@ public class PluginInstallerDialogs {
    */
   public static PluginInstallerCallback.ConsentResult askForInstallationConsentOnCreation(
       @NotNull List<PluginDependency> pluginNames) {
-    Object[] options = {
+    String[] options = {
         getText("ui.pluginInstallationDialog.courseCreateDialog.yesText"),
         getText("ui.pluginInstallationDialog.courseCreateDialog.noText"),
         getText("ui.pluginInstallationDialog.courseCreateDialog.cancelText")
     };
 
-    final int result = JOptionPane.showOptionDialog(null,
+    final int result = Messages.showDialog(
         getAndReplaceText("ui.pluginInstallationDialog.courseCreateDialog.message", pluginListToString(pluginNames)),
-        getText("ui.pluginInstallationDialog.courseCreateDialog.title"), JOptionPane.YES_NO_CANCEL_OPTION,
-        JOptionPane.INFORMATION_MESSAGE, null, options, options[0]);
+        getText("ui.pluginInstallationDialog.courseCreateDialog.title"),
+        options,
+        0,
+        null);
 
-    switch (result) {
-      case 0:
-        return PluginInstallerCallback.ConsentResult.ACCEPTED;
-      case 1:
-        return PluginInstallerCallback.ConsentResult.IGNORE_INSTALL;
-      default:
-        return PluginInstallerCallback.ConsentResult.REJECTED;
-    }
+    return switch (result) {
+      case 0 -> PluginInstallerCallback.ConsentResult.ACCEPTED;
+      case 1 -> PluginInstallerCallback.ConsentResult.IGNORE_INSTALL;
+      default -> PluginInstallerCallback.ConsentResult.REJECTED;
+    };
   }
 
   /**
@@ -49,15 +47,17 @@ public class PluginInstallerDialogs {
    */
   public static PluginInstallerCallback.ConsentResult askForInstallationConsentOnInit(
       @NotNull List<PluginDependency> pluginNames) {
-    Object[] options = {
+    String[] options = {
         getText("ui.pluginInstallationDialog.courseOpenDialog.yesText"),
         getText("ui.pluginInstallationDialog.courseOpenDialog.noText")
     };
 
-    final int result = JOptionPane.showOptionDialog(null,
+    final int result = Messages.showDialog(
         getAndReplaceText("ui.pluginInstallationDialog.courseOpenDialog.message", pluginListToString(pluginNames)),
-        getText("ui.pluginInstallationDialog.courseOpenDialog.title"), JOptionPane.YES_NO_OPTION,
-        JOptionPane.INFORMATION_MESSAGE, null, options, options[0]);
+        getText("ui.pluginInstallationDialog.courseOpenDialog.title"),
+        options,
+        0,
+        null);
 
     return result == 0 ? PluginInstallerCallback.ConsentResult.ACCEPTED
         : PluginInstallerCallback.ConsentResult.IGNORE_INSTALL;


### PR DESCRIPTION
# Description of the PR
Fixes #1087 

As described in the issue, JOptionPane is now causing some troubles with thread contexts. Therefore it has been replaced with IntelliJ Platform API.
I was unable to easily replace one instance of JOptionPane, but fortunately a workaround exists.