### PR TITLE
Implemented tag compatibility

### DIFF
--- a/src/main/kotlin/fi/aalto/cs/apluscourses/model/exercise/Exercise.kt
+++ b/src/main/kotlin/fi/aalto/cs/apluscourses/model/exercise/Exercise.kt
@@ -36,8 +36,8 @@ data class Exercise(
     /**
      * Returns the best submission of this exercise (if one exists).
      */
-    private fun bestSubmission(): SubmissionResult? { //this may need some adjustments
-        //aina oletuksena se, jonka api saa palvelimelta, mutta jos löytyy ilman varoitustunnistetta, välitä se eteenpäin
+    private fun bestSubmission(): SubmissionResult? {
+        //the best submission is always assumed to be the one returned by api, but if there is another one with equal/higher points and no 'warn', it is treated as the best locally
         val best = submissionResults.find { it.id == bestSubmissionId }
         return submissionResults.find { !it.hasTag("warn") && it.userPoints >= (best?.userPoints ?: 0) } ?: best
     }

--- a/src/main/kotlin/fi/aalto/cs/apluscourses/model/exercise/SubmissionResult.kt
+++ b/src/main/kotlin/fi/aalto/cs/apluscourses/model/exercise/SubmissionResult.kt
@@ -10,7 +10,7 @@ data class SubmissionResult(
     val maxPoints: Int,
     var userPoints: Int,
     var latePenalty: Double?,
-    var tags: List<String>, //tags arrive here from SubmissinData through ExerciseUpdater
+    var tags: List<String>,
     var status: Status,
     val filesInfo: List<SubmissionFileInfo>,
     val submitters: List<Long>?,

--- a/src/main/kotlin/fi/aalto/cs/apluscourses/services/exercise/ExercisesUpdater.kt
+++ b/src/main/kotlin/fi/aalto/cs/apluscourses/services/exercise/ExercisesUpdater.kt
@@ -175,7 +175,7 @@ class ExercisesUpdater(
         this.points = newPoints
         this.submissionCount = newSubmissionCount
         val exercisesResponseDeferred = withContext(Dispatchers.IO) { async { courseApi.exercises(project) } }
-        val submissionDataResponseDeferred = withContext(Dispatchers.IO) { async { courseApi.submissionData(project) } }//TODO: tästä se sa palautukset ja mm. tunnisteet!
+        val submissionDataResponseDeferred = withContext(Dispatchers.IO) { async { courseApi.submissionData(project) } }
 
         val exercises = exercisesResponseDeferred.await()
         val submissionDataResponse = submissionDataResponseDeferred.await()
@@ -207,7 +207,7 @@ class ExercisesUpdater(
                         module = course.exerciseModules[exercise.id]?.get(selectedLanguage),
                         htmlUrl = exerciseExercise?.htmlUrl ?: "",
                         url = exercise.url,
-                        submissionResults = exercise //tässä luultavasti tapahtuu muunnos
+                        submissionResults = exercise
                             .submissionsWithPoints
                             .map {
                                 val data = submissionData[it.id]
@@ -221,13 +221,13 @@ class ExercisesUpdater(
                                     status = SubmissionResult.statusFromString(data?.Status),
                                     filesInfo = emptyList(),
                                     submitters = submitters,
-                                    tags = data?.Tags?.split("|")?.map { it.trim() } ?: emptyList() //emptyList() //listOf("warn") // TODO: remember to uncomment after testing data?.Tags?.split("|").map { it.trim() } ?: emptyList()
+                                    tags = data?.Tags?.split("|")?.map { it.trim() } ?: emptyList()
                                 )
                             }.toMutableList(),
                         maxPoints = exercise.maxPoints,
-                        userPoints = exercise.points, //exercise.points palauttaa aina tehtävän parhaat pisteet
+                        userPoints = exercise.points,
                         maxSubmissions = exerciseExercise?.maxSubmissions ?: 0,
-                        bestSubmissionId = exercise.bestSubmission?.split("/")?.last()?.toLong(), //TODO: tämä pitää luultavasti myös muuttaa
+                        bestSubmissionId = exercise.bestSubmission?.split("/")?.last()?.toLong(),
                         difficulty = exercise.difficulty,
                         isSubmittable = exerciseExercise?.hasSubmittableFiles == true,
                         isOptional = optionalCategories.contains(exercise.difficulty),
@@ -273,13 +273,7 @@ class ExercisesUpdater(
                             submissionResult.updateStatus(submission.status)
                             submissionResult.userPoints = submission.grade
                             submissionResult.latePenalty = submission.latePenaltyApplied
-                            //ignore unknown keys?
-                            //val json = Json { ignoreUnknownKeys = true }
-                            //TODO: muista palauttaa tyhjä lista testauksen jälkeen
                             submissionResult.tags = submission.submissionTags
-                            //println(submission?.gradingData)
-                                    //json.decodeFromString<APlusApi.Submission.InnerData>(submission.gradingData?.gradingData ?: "\"submission_tags\":\"\"").submissionTags?.split(",") ?: emptyList()
-                            //tänne myös tunnisteet, koska jokaisella palautuskerralla ne päivittyy
                             Notifier.notify(FeedbackAvailableNotification(submissionResult, exercise, project), project)
                             fireExerciseUpdated(exercise)
                         }

--- a/src/main/kotlin/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.kt
+++ b/src/main/kotlin/fi/aalto/cs/apluscourses/ui/exercise/ExercisesTreeRenderer.kt
@@ -181,19 +181,18 @@ class ExercisesTreeRenderer : NodeRenderer() {
         }
     }
 
-    private fun statusToColor(status: Status): Color { //tämä on vastuussa koko tehtävän väristä
+    private fun statusToColor(status: Status): Color {
         val baseColor = when (status) {
             Status.FULL_POINTS -> JBColor(0x8bc34a, 0x8bc34a)
-            Status.NO_POINTS, Status.PARTIAL_POINTS -> JBColor(0xffb74d, 0xffb74d) //kuseeko tämä?
+            Status.NO_POINTS, Status.PARTIAL_POINTS -> JBColor(0xffb74d, 0xffb74d)
             else -> JBColor(0xc5c5c5, 0xc5c5c5)
         }
         return if (isSubmittable()) baseColor else ColorUtil.withAlpha(baseColor, 0.5)
     }
 
     //määrittelee yksittäisen palautksen väriä
-    private fun submissionResultToColor(submission: SubmissionResult): Color { //tämä aiheuttaa luultavasti väärän värin palautuksen jälkeen
-        //toinen ehto antaa aina true viimeisellä palautuksella jostain syystä
-        return if (submission.userPoints == submission.maxPoints && !submission.hasTag("warn")) { //virhe oli tunnisteiden tallentamisessa, nyt toimii
+    private fun submissionResultToColor(submission: SubmissionResult): Color {
+        return if (submission.userPoints == submission.maxPoints && !submission.hasTag("warn")) {
             JBColor(0x8bc34a, 0x8bc34a)
         } else {
             JBColor(0xffb74d, 0xffb74d)
@@ -275,23 +274,21 @@ class ExercisesTreeRenderer : NodeRenderer() {
     }
 
     companion object {
-        private fun getStatus(exercise: Exercise): Status { //set status to warn if the tag is set or change how PARTIAL_POINTS works?
+        private fun getStatus(exercise: Exercise): Status {
             return if (exercise.isInGrading()) {
                 Status.IN_GRADING
             } else if (exercise.isOptional) {
                 Status.OPTIONAL_PRACTICE
             } else if (exercise.submissionResults.isEmpty()) {
                 Status.NO_SUBMISSIONS
-            } else if (exercise.userPoints == exercise.maxPoints && !exercise.bestHasWarn()) { //toinen ehto antaa aina true viimeisen palautuksen jälkeen
-                //TODO: yksittäisestä tehtävästä jossa on warn voi edelleen tulla vihreät pisteet, jos avaa intellij uudestaan sit muuttuu keltaiseksi
-                //println("warn is not set!")
+            } else if (exercise.userPoints == exercise.maxPoints && !exercise.bestHasWarn()) {
                 Status.FULL_POINTS
             } else if (exercise.isLate()) {
                 Status.LATE
             } else if (exercise.userPoints == 0) {
                 Status.NO_POINTS
             } else {
-                Status.PARTIAL_POINTS //koska tämä on oeltustila, voi vain katsoa jos on tyäydet pisteet eikä warn-tunnistetta
+                Status.PARTIAL_POINTS
             }
         }
 
@@ -301,7 +298,7 @@ class ExercisesTreeRenderer : NodeRenderer() {
                 Status.OPTIONAL_PRACTICE -> CoursesIcons.OptionalPractice
                 Status.NO_SUBMISSIONS -> CoursesIcons.NoSubmissions
                 Status.NO_POINTS -> CoursesIcons.NoPoints
-                Status.PARTIAL_POINTS -> CoursesIcons.PartialPoints //warning should probably be incorporated into this
+                Status.PARTIAL_POINTS -> CoursesIcons.PartialPoints
                 Status.FULL_POINTS -> CoursesIcons.FullPoints
                 Status.LATE -> CoursesIcons.Late
                 Status.IN_GRADING -> CoursesIcons.Loading


### PR DESCRIPTION
# Description of the PR

Plugin now fetches submission tags set by the grader from api endpoints submissiondata/me and submissions/{id}. Tags arrive in different formats from both endpoints, so they had to be formatted separately. Some changes were also implemented to the logic behind finding the best submission: as the api id for the best submission only considers highest points, the plugin builds on that by taking tags into account and will test if there exists a submission with better points and no "warn" tag set, always preferring them over the tagged ones. 

I have tested new changed by testing it with different combinations of submissions both on the live 2025 and local course version. Due to the fact that the live version of A+ does not currently support tags on the submissiondata path, I had to test it locally and I tested the submissions/{id} path globally. The tests were manual and involved different combinations of assignments with missing points, full points, errors, tags set and not. As I had to test both paths on different servers, some small errors might occur, but I tried to be as meticulous with my tests as I could. 

Note that if you want to test these changes, you might want to use the A+ image at mxkaj/run-aplus-front:1.29-v1, since the current one (as of 24.7.2025) does not provide tags on the submissiondata path.