### PR TITLE
Do not use ATOMIC_MOVE option when moving downloaded files

### DIFF
--- a/src/main/kotlin/fi/aalto/cs/apluscourses/services/CoursesClient.kt
+++ b/src/main/kotlin/fi/aalto/cs/apluscourses/services/CoursesClient.kt
@@ -152,8 +152,7 @@ class CoursesClient(
                     Files.move(
                         tempFile.toPath(),
                         target,
-                        StandardCopyOption.REPLACE_EXISTING,
-                        StandardCopyOption.ATOMIC_MOVE
+                        StandardCopyOption.REPLACE_EXISTING
                     )
                 }
             }


### PR DESCRIPTION
[JDK Specs](https://cr.openjdk.org/~iris/se/21/build/latest/api/java.base/java/nio/file/Files.html#move(java.nio.file.Path,java.nio.file.Path,java.nio.file.CopyOption...)):
>ATOMIC_MOVE
> 	The move is performed as an atomic file system operation and all other options are ignored. If the target file exists then it is implementation specific if the existing file is replaced or this method fails by throwing an `IOException`. If the move cannot be performed as an atomic file system operation then `AtomicMoveNotSupportedException` is thrown. This can arise, for example, when the target location is on a different `FileStore` and would require that the file be copied, or target location is associated with a different provider to this object.

Reportedly, it throws `AtomicMoveNotSupportedException` on Juha's Windows machine where temp files are located in a different drive than the project folder.

Anyway, it seems that having both `REPLACE_EXISTING` and `ATOMIC_MOVE` options makes no sense as the former is ignored.